### PR TITLE
fix: handle Enterprise SSO usage via REST

### DIFF
--- a/Kiro-account-manager/src/main/index.ts
+++ b/Kiro-account-manager/src/main/index.ts
@@ -16,7 +16,7 @@ import {
   type KProxyConfig,
   type DeviceIdMapping
 } from './kproxy'
-import { fetchKiroModels, fetchSubscriptionToken, fetchAvailableSubscriptions, setUserPreference, setUseKProxyForApiInProxy, setLogStreamEvents, setPayloadSizeLimitKB, setTokenBufferReserve, setEnableTokenBufferReserve } from './proxy/kiroApi'
+import { fetchKiroModels, fetchSubscriptionToken, fetchAvailableSubscriptions, setUserPreference, setUseKProxyForApiInProxy, setLogStreamEvents, setPayloadSizeLimitKB, setTokenBufferReserve, setEnableTokenBufferReserve, resolveAccountProfileArn } from './proxy/kiroApi'
 import { getSystemProxy, safeCreateProxyAgent } from './proxy/systemProxy'
 import { proxyLogStore, interceptConsole } from './proxy/logger'
 import { registerIPCHandlers as registerRegistrationHandlers } from './registration/ipc-handlers'
@@ -1095,6 +1095,68 @@ function normalizeResetDate(value: number | string | undefined): string | undefi
   return value
 }
 
+function isEnterpriseIdp(idp?: string): boolean {
+  return idp === 'Enterprise' || idp === 'IAM_SSO' || idp === 'AWSIdC'
+}
+
+function normalizeUsageLimitsResponse(result: UsageLimitsResponse): UnifiedUsageResponse {
+  return {
+    usageBreakdownList: result.usageBreakdownList?.map(b => ({
+      resourceType: b.resourceType || b.type,
+      displayName: b.displayName,
+      displayNamePlural: b.displayNamePlural,
+      currentUsage: b.currentUsage,
+      currentUsageWithPrecision: b.currentUsageWithPrecision,
+      usageLimit: b.usageLimit,
+      usageLimitWithPrecision: b.usageLimitWithPrecision,
+      currency: b.currency,
+      unit: b.unit,
+      overageRate: b.overageRate,
+      overageCap: b.overageCap,
+      type: b.type,
+      // REST API 直接返回 freeTrialInfo，CBOR API 返回 freeTrialUsage
+      freeTrialInfo: b.freeTrialInfo ? {
+        freeTrialStatus: b.freeTrialInfo.freeTrialStatus,
+        usageLimit: b.freeTrialInfo.usageLimit,
+        usageLimitWithPrecision: b.freeTrialInfo.usageLimitWithPrecision,
+        currentUsage: b.freeTrialInfo.currentUsage,
+        currentUsageWithPrecision: b.freeTrialInfo.currentUsageWithPrecision,
+        // REST API 返回数字时间戳，需要转换为 ISO 字符串
+        freeTrialExpiry: typeof b.freeTrialInfo.freeTrialExpiry === 'number'
+          ? new Date(b.freeTrialInfo.freeTrialExpiry * 1000).toISOString()
+          : b.freeTrialInfo.freeTrialExpiry
+      } : (b.freeTrialUsage ? {
+        freeTrialStatus: b.freeTrialUsage.freeTrialStatus,
+        usageLimit: b.freeTrialUsage.usageLimit,
+        usageLimitWithPrecision: b.freeTrialUsage.usageLimitWithPrecision,
+        currentUsage: b.freeTrialUsage.currentUsage,
+        currentUsageWithPrecision: b.freeTrialUsage.currentUsageWithPrecision,
+        freeTrialExpiry: b.freeTrialUsage.freeTrialExpiry
+      } : undefined),
+      // 转换 bonuses 中的时间戳为 ISO 字符串
+      bonuses: b.bonuses?.map(bonus => ({
+        ...bonus,
+        expiresAt: typeof bonus.expiresAt === 'number'
+          ? new Date(bonus.expiresAt * 1000).toISOString()
+          : bonus.expiresAt
+      }))
+    })),
+    // REST API 返回的 nextDateReset 是 Unix 时间戳（秒），需要转换为 ISO 字符串
+    nextDateReset: normalizeResetDate(result.nextDateReset),
+    subscriptionInfo: result.subscriptionInfo,
+    overageConfiguration: result.overageConfiguration,
+    userInfo: result.userInfo
+  }
+}
+
+function shouldFallbackCborUsageToRest(errorMessage: string): boolean {
+  return errorMessage.includes('401')
+    || errorMessage.includes('403')
+    || errorMessage.includes('400')
+    || errorMessage.includes('BadRequestException')
+    || errorMessage.toLowerCase().includes('invalid parameters')
+}
+
 async function fetchRestApi(
   baseUrl: string,
   path: string,
@@ -1227,57 +1289,21 @@ async function getUsageAndLimits(
   ssoRegion?: string,         // SSO 区域，用于选择正确的 REST API 端点
   email?: string              // 用于日志标识
 ): Promise<UnifiedUsageResponse> {
-  if (currentUsageApiType === 'rest') {
+  const resolvedProfileArn = profileArn || (isEnterpriseIdp(idp)
+    ? await resolveAccountProfileArn({
+        id: email || 'usage-request',
+        email,
+        accessToken,
+        region: ssoRegion || 'us-east-1',
+        provider: idp,
+        machineId: accountMachineId
+      } as ProxyAccount)
+    : undefined)
+
+  if (currentUsageApiType === 'rest' || isEnterpriseIdp(idp)) {
     // 使用 REST API (GetUsageLimits)
-    const result = await getUsageLimitsRest(accessToken, profileArn, accountMachineId, ssoRegion, email)
-    // REST API 返回的字段名和 CBOR API 相同，直接返回
-    return {
-      usageBreakdownList: result.usageBreakdownList?.map(b => ({
-        resourceType: b.resourceType || b.type,
-        displayName: b.displayName,
-        displayNamePlural: b.displayNamePlural,
-        currentUsage: b.currentUsage,
-        currentUsageWithPrecision: b.currentUsageWithPrecision,
-        usageLimit: b.usageLimit,
-        usageLimitWithPrecision: b.usageLimitWithPrecision,
-        currency: b.currency,
-        unit: b.unit,
-        overageRate: b.overageRate,
-        overageCap: b.overageCap,
-        type: b.type,
-        // REST API 直接返回 freeTrialInfo，CBOR API 返回 freeTrialUsage
-        freeTrialInfo: b.freeTrialInfo ? {
-          freeTrialStatus: b.freeTrialInfo.freeTrialStatus,
-          usageLimit: b.freeTrialInfo.usageLimit,
-          usageLimitWithPrecision: b.freeTrialInfo.usageLimitWithPrecision,
-          currentUsage: b.freeTrialInfo.currentUsage,
-          currentUsageWithPrecision: b.freeTrialInfo.currentUsageWithPrecision,
-          // REST API 返回数字时间戳，需要转换为 ISO 字符串
-          freeTrialExpiry: typeof b.freeTrialInfo.freeTrialExpiry === 'number' 
-            ? new Date(b.freeTrialInfo.freeTrialExpiry * 1000).toISOString() 
-            : b.freeTrialInfo.freeTrialExpiry
-        } : (b.freeTrialUsage ? {
-          freeTrialStatus: b.freeTrialUsage.freeTrialStatus,
-          usageLimit: b.freeTrialUsage.usageLimit,
-          usageLimitWithPrecision: b.freeTrialUsage.usageLimitWithPrecision,
-          currentUsage: b.freeTrialUsage.currentUsage,
-          currentUsageWithPrecision: b.freeTrialUsage.currentUsageWithPrecision,
-          freeTrialExpiry: b.freeTrialUsage.freeTrialExpiry
-        } : undefined),
-        // 转换 bonuses 中的时间戳为 ISO 字符串
-        bonuses: b.bonuses?.map(bonus => ({
-          ...bonus,
-          expiresAt: typeof bonus.expiresAt === 'number' 
-            ? new Date(bonus.expiresAt * 1000).toISOString() 
-            : bonus.expiresAt
-        }))
-      })),
-      // REST API 返回的 nextDateReset 是 Unix 时间戳（秒），需要转换为 ISO 字符串
-      nextDateReset: normalizeResetDate(result.nextDateReset),
-      subscriptionInfo: result.subscriptionInfo,
-      overageConfiguration: result.overageConfiguration,
-      userInfo: result.userInfo
-    }
+    const result = await getUsageLimitsRest(accessToken, resolvedProfileArn, accountMachineId, ssoRegion, email)
+    return normalizeUsageLimitsResponse(result)
   } else {
     // 使用 CBOR API (GetUserUsageAndLimits)
     // CBOR API (app.kiro.dev) 是网页端门户，仅支持 BuilderId 认证
@@ -1293,53 +1319,11 @@ async function getUsageAndLimits(
       )
     } catch (cborError) {
       const errorMsg = cborError instanceof Error ? cborError.message : ''
-      // CBOR 401/403 时自动 fallback 到 REST API
-      if (errorMsg.includes('401') || errorMsg.includes('403')) {
+      // CBOR 失败时自动 fallback 到 REST API（Enterprise/IdC 常见 400 invalid parameters）
+      if (shouldFallbackCborUsageToRest(errorMsg)) {
         console.log(`[API] CBOR API failed (${errorMsg}), falling back to REST API...`)
-        const result = await getUsageLimitsRest(accessToken, profileArn, accountMachineId, ssoRegion, email)
-        return {
-          usageBreakdownList: result.usageBreakdownList?.map(b => ({
-            resourceType: b.resourceType || b.type,
-            displayName: b.displayName,
-            displayNamePlural: b.displayNamePlural,
-            currentUsage: b.currentUsage,
-            currentUsageWithPrecision: b.currentUsageWithPrecision,
-            usageLimit: b.usageLimit,
-            usageLimitWithPrecision: b.usageLimitWithPrecision,
-            currency: b.currency,
-            unit: b.unit,
-            overageRate: b.overageRate,
-            overageCap: b.overageCap,
-            type: b.type,
-            freeTrialInfo: b.freeTrialInfo ? {
-              freeTrialStatus: b.freeTrialInfo.freeTrialStatus,
-              usageLimit: b.freeTrialInfo.usageLimit,
-              usageLimitWithPrecision: b.freeTrialInfo.usageLimitWithPrecision,
-              currentUsage: b.freeTrialInfo.currentUsage,
-              currentUsageWithPrecision: b.freeTrialInfo.currentUsageWithPrecision,
-              freeTrialExpiry: typeof b.freeTrialInfo.freeTrialExpiry === 'number' 
-                ? new Date(b.freeTrialInfo.freeTrialExpiry * 1000).toISOString() 
-                : b.freeTrialInfo.freeTrialExpiry
-            } : (b.freeTrialUsage ? {
-              freeTrialStatus: b.freeTrialUsage.freeTrialStatus,
-              usageLimit: b.freeTrialUsage.usageLimit,
-              usageLimitWithPrecision: b.freeTrialUsage.usageLimitWithPrecision,
-              currentUsage: b.freeTrialUsage.currentUsage,
-              currentUsageWithPrecision: b.freeTrialUsage.currentUsageWithPrecision,
-              freeTrialExpiry: b.freeTrialUsage.freeTrialExpiry
-            } : undefined),
-            bonuses: b.bonuses?.map(bonus => ({
-              ...bonus,
-              expiresAt: typeof bonus.expiresAt === 'number' 
-                ? new Date(bonus.expiresAt * 1000).toISOString() 
-                : bonus.expiresAt
-            }))
-          })),
-          nextDateReset: normalizeResetDate(result.nextDateReset as unknown as number | string),
-          subscriptionInfo: result.subscriptionInfo,
-          overageConfiguration: result.overageConfiguration,
-          userInfo: result.userInfo
-        }
+        const result = await getUsageLimitsRest(accessToken, resolvedProfileArn, accountMachineId, ssoRegion, email)
+        return normalizeUsageLimitsResponse(result)
       }
       throw cborError
     }
@@ -3659,7 +3643,14 @@ app.whenReady().then(async () => {
         userInfo?: { email?: string; userId?: string }
       }
       
-      const usageResult = await getUsageAndLimits(refreshResult.accessToken, idp, undefined, undefined, region) as UsageResponse
+      const resolvedProfileArn = await resolveAccountProfileArn({
+        id: 'verify-account',
+        accessToken: refreshResult.accessToken,
+        region,
+        provider: idp,
+        authMethod
+      } as ProxyAccount)
+      const usageResult = await getUsageAndLimits(refreshResult.accessToken, idp, resolvedProfileArn, undefined, region) as UsageResponse
       
       // 解析用户信息
       const email = usageResult.userInfo?.email || ''
@@ -3736,6 +3727,7 @@ app.whenReady().then(async () => {
           userId,
           accessToken: refreshResult.accessToken,
           refreshToken: refreshResult.refreshToken || refreshToken,
+          profileArn: resolvedProfileArn,
           expiresIn: refreshResult.expiresIn,
           subscriptionType,
           subscriptionTitle,
@@ -3826,6 +3818,7 @@ app.whenReady().then(async () => {
         region?: string
         authMethod?: string
         provider?: string
+        profileArn?: string
       }
       
       try {
@@ -3833,6 +3826,19 @@ app.whenReady().then(async () => {
         tokenData = JSON.parse(tokenContent)
       } catch {
         return { success: false, error: '找不到 kiro-auth-token.json 文件，请先在 Kiro IDE 中登录' }
+      }
+
+      if (!tokenData.profileArn) {
+        try {
+          const profilePath = path.join(os.homedir(), 'Library', 'Application Support', 'Kiro', 'User', 'globalStorage', 'kiro.kiroagent', 'profile.json')
+          const profileData = JSON.parse(await readFile(profilePath, 'utf-8'))
+          if (profileData?.arn) {
+            tokenData.profileArn = profileData.arn
+            console.log('[Kiro Credentials] Loaded profileArn from Kiro profile storage')
+          }
+        } catch {
+          // profile.json is optional; ListAvailableProfiles will be used when needed
+        }
       }
       
       if (!tokenData.refreshToken) {
@@ -3905,7 +3911,8 @@ app.whenReady().then(async () => {
           clientSecret: clientData?.clientSecret || '',
           region: tokenData.region || 'us-east-1',
           authMethod: tokenData.authMethod || 'IdC',
-          provider: tokenData.provider || 'BuilderId'
+          provider: tokenData.provider || 'BuilderId',
+          profileArn: tokenData.profileArn
         }
       }
     } catch (error) {
@@ -3972,7 +3979,9 @@ app.whenReady().then(async () => {
       const SOCIAL_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK'
       const BUILDER_ID_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX'
       const resolvedProfileArn = profileArn
-        || (authMethod === 'social' || provider === 'Google' || provider === 'Github' ? SOCIAL_PROFILE_ARN : BUILDER_ID_PROFILE_ARN)
+        || (authMethod === 'social' || provider === 'Google' || provider === 'Github' ? SOCIAL_PROFILE_ARN : undefined)
+        || (provider === 'Enterprise' ? await resolveAccountProfileArn({ id: 'switch-account', accessToken, region, provider, authMethod } as ProxyAccount) : undefined)
+        || (provider === 'BuilderId' ? BUILDER_ID_PROFILE_ARN : undefined)
 
       // 写入 token 文件（格式与官方 Kiro IDE 完全一致）
       const tokenPath = path.join(ssoCache, 'kiro-auth-token.json')
@@ -3994,9 +4003,11 @@ app.whenReady().then(async () => {
             clientIdHash,
             authMethod,
             provider,
-            region,
-            profileArn: resolvedProfileArn
+            region
           }
+      if (resolvedProfileArn) {
+        tokenData.profileArn = resolvedProfileArn
+      }
       await writeFile(tokenPath, JSON.stringify(tokenData, null, 2))
       console.log('[Switch Account] Token saved to:', tokenPath)
       
@@ -4085,7 +4096,10 @@ app.whenReady().then(async () => {
       // 根据 provider 推导 profileArn
       const SOCIAL_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK'
       const BUILDER_ID_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX'
-      const resolvedProfileArn = profileArn || (isSocial ? SOCIAL_PROFILE_ARN : BUILDER_ID_PROFILE_ARN)
+      const resolvedProfileArn = profileArn
+        || (isSocial ? SOCIAL_PROFILE_ARN : undefined)
+        || (provider === 'Enterprise' ? await resolveAccountProfileArn({ id: 'switch-cli', accessToken, region, provider } as ProxyAccount) : undefined)
+        || (provider === 'Enterprise' ? undefined : BUILDER_ID_PROFILE_ARN)
 
       // 构建 token JSON（snake_case 字段名，与 kiro-cli Rust 结构一致）
       const expiresAt = new Date(Date.now() + 3600 * 1000).toISOString()
@@ -4872,7 +4886,8 @@ app.whenReady().then(async () => {
         clientId: account.credentials?.clientId,
         clientSecret: account.credentials?.clientSecret,
         region: account.credentials?.region || 'us-east-1',
-        authMethod: account.credentials?.authMethod
+        authMethod: account.credentials?.authMethod,
+        provider: account.credentials?.provider || account.idp
       }
 
       const models = await fetchKiroModels(proxyAccount)

--- a/Kiro-account-manager/src/main/proxy/kiroApi.ts
+++ b/Kiro-account-manager/src/main/proxy/kiroApi.ts
@@ -1,6 +1,12 @@
 // Kiro API 调用核心模块
+import { createHash } from 'crypto'
+import { release } from 'os'
 import { v4 as uuidv4 } from 'uuid'
-import { fetch as undiciFetch, type RequestInit as UndiciRequestInit, type Dispatcher } from 'undici'
+import {
+  fetch as undiciFetch,
+  type RequestInit as UndiciRequestInit,
+  type Dispatcher
+} from 'undici'
 import type {
   KiroPayload,
   KiroUserInputMessage,
@@ -115,7 +121,11 @@ function getNetworkAgent(account?: ProxyAccount): Dispatcher | undefined {
     }
   }
   // 3. 环境变量
-  const envProxy = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy
+  const envProxy =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy
   const envAgent = safeCreateProxyAgent(envProxy)
   if (envAgent) return envAgent
   // 4. 系统代理
@@ -126,17 +136,35 @@ function getNetworkAgent(account?: ProxyAccount): Dispatcher | undefined {
  * 使用代理的 fetch 函数
  * 传入 account 时会优先使用账号绑定的代理（账号-代理 N:1 分桶）
  */
-async function fetchWithProxy(url: string, options: RequestInit, account?: ProxyAccount): Promise<Response> {
+async function fetchWithProxy(
+  url: string,
+  options: RequestInit,
+  account?: ProxyAccount
+): Promise<Response> {
   const agent = getNetworkAgent(account)
   if (agent) {
     proxyLogger.debug('KiroAPI', `Using proxy agent: ${agent.constructor.name}`)
-    return await undiciFetch(url, { ...options, dispatcher: agent } as UndiciRequestInit) as unknown as Response
+    return (await undiciFetch(url, {
+      ...options,
+      dispatcher: agent
+    } as UndiciRequestInit)) as unknown as Response
   }
   return await fetch(url, options)
 }
 
+type KiroEndpointName = 'CodeWhisperer' | 'AmazonQ' | 'AmazonQCLI'
+type KiroEndpointProtocol = 'generateAssistantResponse' | 'rpcJson'
+
+interface KiroEndpoint {
+  url: string
+  origin: string
+  amzTarget: string
+  name: KiroEndpointName
+  protocol: KiroEndpointProtocol
+}
+
 // Kiro API 端点配置
-const KIRO_ENDPOINTS = [
+const KIRO_ENDPOINTS: KiroEndpoint[] = [
   {
     url: 'https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse',
     origin: 'AI_EDITOR',
@@ -152,47 +180,142 @@ const KIRO_ENDPOINTS = [
     protocol: 'generateAssistantResponse' as const
   },
   {
-    url: 'https://q.us-east-1.amazonaws.com/SendMessageStreaming',
-    origin: 'CLI',
-    amzTarget: 'AmazonQDeveloperStreamingService.SendMessage',
-    name: 'AmazonQCLI'
+    url: 'https://q.us-east-1.amazonaws.com/',
+    origin: 'KIRO_CLI',
+    amzTarget: 'AmazonCodeWhispererStreamingService.GenerateAssistantResponse',
+    name: 'AmazonQCLI',
+    protocol: 'rpcJson' as const
   }
 ]
 
 // Kiro 版本号（跟随官方 IDE 更新）
-const KIRO_VERSION = '0.12.155'
-const AWS_SDK_VERSION = '1.0.34'
-const AWS_STREAMING_API_VERSION = '1.0.34'
+const KIRO_VERSION = '0.12.263'
+const AWS_SDK_VERSION = '1.0.39'
+const AWS_STREAMING_API_VERSION = '1.0.39'
 
-const OS_PLATFORM = process.platform === 'win32' ? 'win32' : process.platform === 'darwin' ? 'macos' : 'linux'
-const OS_RELEASE = (() => { try { return require('os').release() } catch { return '10.0.0' } })()
+const OS_PLATFORM =
+  process.platform === 'win32' ? 'win32' : process.platform === 'darwin' ? 'macos' : 'linux'
+const OS_RELEASE = (() => {
+  try {
+    return release()
+  } catch {
+    return '10.0.0'
+  }
+})()
 const NODE_VERSION = process.versions.node || '22.22.0'
 
 function getKiroUserAgent(machineId?: string): string {
   const suffix = machineId ? `KiroIDE-${KIRO_VERSION}-${machineId}` : `KiroIDE-${KIRO_VERSION}`
-  return `aws-sdk-js/${AWS_SDK_VERSION} ua/2.1 os/${OS_PLATFORM}#${OS_RELEASE} lang/js md/nodejs#${NODE_VERSION} api/codewhispererstreaming#${AWS_STREAMING_API_VERSION} m/E ${suffix}`
+  return `aws-sdk-js/${AWS_SDK_VERSION} ua/2.1 os/${OS_PLATFORM}#${OS_RELEASE} lang/js md/nodejs#${NODE_VERSION} api/codewhispererstreaming#${AWS_STREAMING_API_VERSION} m/N ${suffix}`
 }
 
 function getKiroAmzUserAgent(machineId?: string): string {
-  const suffix = machineId ? `KiroIDE ${KIRO_VERSION} ${machineId}` : `KiroIDE-${KIRO_VERSION}`
+  const suffix = machineId ? `KiroIDE-${KIRO_VERSION}-${machineId}` : `KiroIDE-${KIRO_VERSION}`
   return `aws-sdk-js/${AWS_SDK_VERSION} ${suffix}`
 }
 
-const KIRO_CLI_OS = OS_PLATFORM === 'win32' ? 'windows' : OS_PLATFORM === 'macos' ? 'macos' : 'linux'
-const KIRO_CLI_USER_AGENT = `aws-sdk-rust/1.3.9 os/${KIRO_CLI_OS} lang/rust/1.87.0`
-const KIRO_CLI_AMZ_USER_AGENT = `aws-sdk-rust/1.3.9 ua/2.1 api/ssooidc/1.88.0 os/${KIRO_CLI_OS} lang/rust/1.87.0 m/E app/AmazonQ-For-CLI`
+const KIRO_CLI_OS =
+  OS_PLATFORM === 'win32' ? 'windows' : OS_PLATFORM === 'macos' ? 'macos' : 'linux'
+const KIRO_CLI_USER_AGENT = `aws-sdk-rust/1.3.16 ua/2.1 api/codewhispererstreaming/0.1.16551 os/${KIRO_CLI_OS} lang/rust/1.92.0 md/appVersion-2.4.2 app/AmazonQ-For-CLI`
+const KIRO_CLI_AMZ_USER_AGENT = `aws-sdk-rust/1.3.16 ua/2.1 api/codewhispererstreaming/0.1.16551 os/${KIRO_CLI_OS} lang/rust/1.92.0 m/F app/AmazonQ-For-CLI`
 
 // Agent 模式
 const AGENT_MODE_SPEC = 'spec' // IDE 模式
 const AGENT_MODE_VIBE = 'vibe' // CLI 模式
 
-const KIRO_BUILDER_ID_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX'
+const KIRO_BUILDER_ID_PROFILE_ARN =
+  'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX'
 const KIRO_SOCIAL_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK'
 
-function resolveProfileArn(account: ProxyAccount): string {
+function isEnterpriseProvider(provider?: string): boolean {
+  return provider === 'Enterprise' || provider === 'IAM_SSO' || provider === 'AWSIdC'
+}
+
+function resolveStaticProfileArn(account: ProxyAccount): string | undefined {
   if (account.profileArn) return account.profileArn
   if (account.provider === 'Github' || account.provider === 'Google') return KIRO_SOCIAL_PROFILE_ARN
+  if (isEnterpriseProvider(account.provider)) return undefined
   return KIRO_BUILDER_ID_PROFILE_ARN
+}
+
+export interface KiroProfile {
+  arn: string
+  name?: string
+  profileName?: string
+}
+
+const accountProfileCache = new Map<string, { profileArn?: string; timestamp: number }>()
+const ACCOUNT_PROFILE_CACHE_TTL = 5 * 60 * 1000
+
+function getAccountProfileCacheKey(account: ProxyAccount): string {
+  return `${account.id}:${account.region || 'us-east-1'}:${account.provider || account.authMethod || 'unknown'}`
+}
+
+export async function fetchKiroProfiles(
+  account: ProxyAccount,
+  signal?: AbortSignal
+): Promise<KiroProfile[]> {
+  const fixedProfileArn = resolveStaticProfileArn(account)
+  if (fixedProfileArn) {
+    return [{ arn: fixedProfileArn, name: account.provider || 'Kiro' }]
+  }
+
+  const baseUrl = getQServiceEndpoint(account.region)
+  const machineId = getAccountMachineId(account.id, account.machineId)
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${account.accessToken}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'User-Agent': getKiroUserAgent(machineId),
+    'x-amz-user-agent': getKiroAmzUserAgent(machineId),
+    'x-amzn-codewhisperer-optout': 'true'
+  }
+
+  const profiles: KiroProfile[] = []
+  let nextToken: string | undefined
+
+  do {
+    const body = JSON.stringify(nextToken ? { nextToken } : {})
+    throwIfAborted(signal)
+    const response = await fetchWithProxy(
+      `${baseUrl}/ListAvailableProfiles`,
+      { method: 'POST', headers, body, signal },
+      account
+    )
+    throwIfAborted(signal)
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '')
+      console.error('[KiroAPI] ListAvailableProfiles failed:', response.status, errorText)
+      break
+    }
+
+    const data = await response.json()
+    profiles.push(...(data.profiles || []))
+    nextToken = data.nextToken
+  } while (nextToken)
+
+  return profiles
+}
+
+export async function resolveAccountProfileArn(
+  account: ProxyAccount,
+  signal?: AbortSignal
+): Promise<string | undefined> {
+  const fixedProfileArn = resolveStaticProfileArn(account)
+  if (fixedProfileArn) return fixedProfileArn
+  if (!isEnterpriseProvider(account.provider)) return undefined
+
+  const cacheKey = getAccountProfileCacheKey(account)
+  const cached = accountProfileCache.get(cacheKey)
+  if (cached && Date.now() - cached.timestamp < ACCOUNT_PROFILE_CACHE_TTL) return cached.profileArn
+
+  const profiles = await fetchKiroProfiles(account, signal)
+  const profileArn = profiles[0]?.arn
+  accountProfileCache.set(cacheKey, { profileArn, timestamp: Date.now() })
+  if (profileArn)
+    console.log(`[KiroAPI] Resolved Enterprise profileArn for ${account.email || account.id}`)
+  return profileArn
 }
 
 // Agentic 模式系统提示 - 防止大文件写入超时
@@ -250,7 +373,7 @@ const MODEL_ID_MAP: Record<string, string> = {
   'gpt-4o': 'claude-sonnet-4.5',
   'gpt-4-turbo': 'claude-sonnet-4.5',
   'gpt-3.5-turbo': 'claude-sonnet-4.5',
-  'default': 'claude-sonnet-4.5'
+  default: 'claude-sonnet-4.5'
 }
 
 export function mapModelId(model: string): string {
@@ -260,6 +383,8 @@ export function mapModelId(model: string): string {
   const lower = modelId.toLowerCase()
   // 1) 显式 alias 映射优先
   if (MODEL_ID_MAP[lower]) return MODEL_ID_MAP[lower]
+  const dottedClaudeAlias = lower.match(/^(claude-(?:sonnet|haiku|opus)-\d+)-(\d+)$/)
+  if (dottedClaudeAlias) return `${dottedClaudeAlias[1]}.${dottedClaudeAlias[2]}`
   // 2) 看似 Kiro 支持的 Claude 模型格式 (claude-{sonnet|haiku|opus}-{ver})，原样透传
   //    用于向前兼容尚未加入 MODEL_ID_MAP 的新发布模型
   if (/^claude-(sonnet|haiku|opus)-/.test(lower)) return modelId
@@ -277,7 +402,10 @@ function normalizeModelKey(value: string): string {
 }
 
 function modelTokens(value: string): string[] {
-  return value.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
 }
 
 function matchesRequestedModel(model: KiroModel, requestedModelId: string): boolean {
@@ -288,11 +416,13 @@ function matchesRequestedModel(model: KiroModel, requestedModelId: string): bool
   // 2. modelName 精确匹配
   if (model.modelName && normalizeModelKey(model.modelName).includes(requestedKey)) return true
   // 3. token 匹配（所有请求 token 必须在 modelId+modelName 中命中，不搜索 description 避免误匹配）
-  const tokens = modelTokens(requestedModelId).filter(token => token !== 'latest' && token !== 'model')
+  const tokens = modelTokens(requestedModelId).filter(
+    (token) => token !== 'latest' && token !== 'model'
+  )
   if (tokens.length === 0) return false
   const candidateTokens = new Set(modelTokens(`${model.modelId} ${model.modelName || ''}`))
   // 必须全部 token 命中
-  if (!tokens.every(token => candidateTokens.has(token))) return false
+  if (!tokens.every((token) => candidateTokens.has(token))) return false
   // 防止模型家族冲突：如果请求包含 opus/sonnet/haiku，候选必须也包含对应的
   const families = ['opus', 'sonnet', 'haiku']
   for (const family of families) {
@@ -306,12 +436,15 @@ function isCodeWhispererModelId(modelId: string): boolean {
   return /^[A-Z0-9_]+$/.test(modelId) && modelId.includes('_')
 }
 
-function getModelCacheKey(account: ProxyAccount): string {
-  return `${account.id}:${account.region || 'us-east-1'}:${resolveProfileArn(account)}`
+async function getModelCacheKey(account: ProxyAccount, signal?: AbortSignal): Promise<string> {
+  return `${account.id}:${account.region || 'us-east-1'}:${(await resolveAccountProfileArn(account, signal)) || 'no-profile'}`
 }
 
-async function getCachedCodeWhispererModels(account: ProxyAccount, signal?: AbortSignal): Promise<KiroModel[]> {
-  const key = getModelCacheKey(account)
+async function getCachedCodeWhispererModels(
+  account: ProxyAccount,
+  signal?: AbortSignal
+): Promise<KiroModel[]> {
+  const key = await getModelCacheKey(account, signal)
   const cached = codeWhispererModelCache.get(key)
   if (cached && Date.now() - cached.timestamp < CODEWHISPERER_MODEL_CACHE_TTL) return cached.models
   const models = await fetchKiroModels(account, signal)
@@ -319,18 +452,26 @@ async function getCachedCodeWhispererModels(account: ProxyAccount, signal?: Abor
   return models
 }
 
-async function resolveCodeWhispererModelId(account: ProxyAccount, requestedModelId?: string, signal?: AbortSignal): Promise<string> {
+async function resolveCodeWhispererModelId(
+  account: ProxyAccount,
+  requestedModelId?: string,
+  signal?: AbortSignal
+): Promise<string> {
   const modelId = requestedModelId?.trim()
   if (!modelId) return CODEWHISPERER_DEFAULT_MODEL_ID
   if (isCodeWhispererModelId(modelId)) return modelId
   const models = await getCachedCodeWhispererModels(account, signal)
-  return models.find(model => matchesRequestedModel(model, modelId))?.modelId || CODEWHISPERER_DEFAULT_MODEL_ID
+  return (
+    models.find((model) => matchesRequestedModel(model, modelId))?.modelId ||
+    CODEWHISPERER_DEFAULT_MODEL_ID
+  )
 }
 
 function getPayloadModelId(payload: KiroPayload): string | undefined {
   const currentModelId = payload.conversationState.currentMessage.userInputMessage.modelId
   if (currentModelId) return currentModelId
-  return payload.conversationState.history?.find(message => message.userInputMessage?.modelId)?.userInputMessage?.modelId
+  return payload.conversationState.history?.find((message) => message.userInputMessage?.modelId)
+    ?.userInputMessage?.modelId
 }
 
 function applyPayloadModelId(payload: KiroPayload, modelId: string): void {
@@ -351,7 +492,9 @@ function applyPayloadOrigin(payload: KiroPayload, origin: string): void {
 export function isAgenticRequest(model: string, tools?: unknown[]): boolean {
   const lower = model.toLowerCase()
   // 模型名称包含 -agentic 或有工具调用
-  return lower.includes('-agentic') || lower.includes('agentic') || Boolean(tools && tools.length > 0)
+  return (
+    lower.includes('-agentic') || lower.includes('agentic') || Boolean(tools && tools.length > 0)
+  )
 }
 
 // 检测是否启用 Thinking 模式
@@ -369,24 +512,24 @@ export function injectSystemPrompts(
   thinkingEnabled: boolean
 ): string {
   let result = content
-  
+
   // 注入时间戳
   const timestamp = new Date().toISOString()
   const timestampPrompt = `Current time: ${timestamp}`
-  
+
   // 注入 Thinking 模式（必须在最前面）
   if (thinkingEnabled) {
     result = THINKING_MODE_PROMPT + '\n\n' + result
   }
-  
+
   // 注入 Agentic 模式提示
   if (isAgentic) {
     result = result + '\n\n' + AGENTIC_SYSTEM_PROMPT
   }
-  
+
   // 注入时间戳
   result = timestampPrompt + '\n\n' + result
-  
+
   return result
 }
 
@@ -424,15 +567,19 @@ function isUserInputMessage(message: KiroHistoryMessage): boolean {
 }
 
 function isAssistantResponseMessage(message: KiroHistoryMessage): boolean {
-  return message != null && 'assistantResponseMessage' in message && message.assistantResponseMessage != null
+  return (
+    message != null &&
+    'assistantResponseMessage' in message &&
+    message.assistantResponseMessage != null
+  )
 }
 
 function hasToolResults(message: KiroHistoryMessage): boolean {
-  return !!(message.userInputMessage?.userInputMessageContext?.toolResults?.length)
+  return !!message.userInputMessage?.userInputMessageContext?.toolResults?.length
 }
 
 function hasToolUses(message: KiroHistoryMessage): boolean {
-  return !!(message.assistantResponseMessage?.toolUses?.length)
+  return !!message.assistantResponseMessage?.toolUses?.length
 }
 
 function hasMatchingToolResults(
@@ -441,12 +588,12 @@ function hasMatchingToolResults(
 ): boolean {
   if (!toolUses || !toolUses.length) return true
   if (!toolResults || !toolResults.length) return false
-  
-  const allToolUsesHaveResults = toolUses.every(
-    toolUse => toolResults.some(result => result.toolUseId === toolUse.toolUseId)
+
+  const allToolUsesHaveResults = toolUses.every((toolUse) =>
+    toolResults.some((result) => result.toolUseId === toolUse.toolUseId)
   )
-  const allToolResultsHaveUses = toolResults.every(
-    result => toolUses.some(toolUse => result.toolUseId === toolUse.toolUseId)
+  const allToolResultsHaveUses = toolResults.every((result) =>
+    toolUses.some((toolUse) => result.toolUseId === toolUse.toolUseId)
   )
   return allToolUsesHaveResults && allToolResultsHaveUses
 }
@@ -489,15 +636,18 @@ function ensureEndsWithUserMessage(messages: KiroHistoryMessage[]): KiroHistoryM
 // 确保消息交替
 function ensureAlternatingMessages(messages: KiroHistoryMessage[]): KiroHistoryMessage[] {
   if (messages.length <= 1) return messages
-  
+
   const result: KiroHistoryMessage[] = [messages[0]]
   for (let i = 1; i < messages.length; i++) {
     const prevMessage = result[result.length - 1]
     const currentMessage = messages[i]
-    
+
     if (isUserInputMessage(prevMessage) && isUserInputMessage(currentMessage)) {
       result.push(UNDERSTOOD_MESSAGE)
-    } else if (isAssistantResponseMessage(prevMessage) && isAssistantResponseMessage(currentMessage)) {
+    } else if (
+      isAssistantResponseMessage(prevMessage) &&
+      isAssistantResponseMessage(currentMessage)
+    ) {
       result.push(CONTINUE_MESSAGE)
     }
     result.push(currentMessage)
@@ -513,7 +663,8 @@ function relocateToolResultMessages(messages: KiroHistoryMessage[]): KiroHistory
     if (isAssistantResponseMessage(message) && hasToolUses(message)) {
       assistantToolUseIndexes.push(i)
     } else if (isUserInputMessage(message) && hasToolResults(message)) {
-      for (const toolResult of message.userInputMessage?.userInputMessageContext?.toolResults ?? []) {
+      for (const toolResult of message.userInputMessage?.userInputMessageContext?.toolResults ??
+        []) {
         if (toolResult.toolUseId && !toolResultIndexById.has(toolResult.toolUseId)) {
           toolResultIndexById.set(toolResult.toolUseId, i)
         }
@@ -534,7 +685,11 @@ function relocateToolResultMessages(messages: KiroHistoryMessage[]): KiroHistory
     if (isAssistantResponseMessage(message) && hasToolUses(message)) {
       for (const toolUse of message.assistantResponseMessage?.toolUses ?? []) {
         const toolResultIndex = toolResultIndexById.get(toolUse.toolUseId)
-        if (toolResultIndex !== undefined && toolResultIndex !== i + 1 && !usedIndexes.has(toolResultIndex)) {
+        if (
+          toolResultIndex !== undefined &&
+          toolResultIndex !== i + 1 &&
+          !usedIndexes.has(toolResultIndex)
+        ) {
           const toolResultMessage = messages[toolResultIndex]
           if (toolResultMessage) {
             result.push(toolResultMessage)
@@ -556,17 +711,30 @@ function removeInvalidToolResultMessages(messages: KiroHistoryMessage[]): KiroHi
       result.push(message)
       continue
     }
-    if (!previousMessage || !isAssistantResponseMessage(previousMessage) || !hasToolUses(previousMessage)) {
+    if (
+      !previousMessage ||
+      !isAssistantResponseMessage(previousMessage) ||
+      !hasToolUses(previousMessage)
+    ) {
       const stripped = stripInvalidToolResults(message)
       if (stripped) result.push(stripped)
       continue
     }
 
-    const validToolUseIds = new Set((previousMessage.assistantResponseMessage?.toolUses ?? []).map(toolUse => toolUse.toolUseId).filter(Boolean))
+    const validToolUseIds = new Set(
+      (previousMessage.assistantResponseMessage?.toolUses ?? [])
+        .map((toolUse) => toolUse.toolUseId)
+        .filter(Boolean)
+    )
     const seenToolUseIds = new Set<string>()
     const toolResults = message.userInputMessage?.userInputMessageContext?.toolResults ?? []
-    const filteredToolResults = toolResults.filter(toolResult => {
-      if (!toolResult.toolUseId || !validToolUseIds.has(toolResult.toolUseId) || seenToolUseIds.has(toolResult.toolUseId)) return false
+    const filteredToolResults = toolResults.filter((toolResult) => {
+      if (
+        !toolResult.toolUseId ||
+        !validToolUseIds.has(toolResult.toolUseId) ||
+        seenToolUseIds.has(toolResult.toolUseId)
+      )
+        return false
       seenToolUseIds.add(toolResult.toolUseId)
       return true
     })
@@ -594,39 +762,53 @@ function removeInvalidToolResultMessages(messages: KiroHistoryMessage[]): KiroHi
 // 确保工具调用有对应结果
 function ensureValidToolUsesAndResults(messages: KiroHistoryMessage[]): KiroHistoryMessage[] {
   const result: KiroHistoryMessage[] = []
-  
+
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i]
     result.push(message)
-    
+
     if (isAssistantResponseMessage(message) && hasToolUses(message)) {
       const nextMessage = i + 1 < messages.length ? messages[i + 1] : null
       const toolUses = message.assistantResponseMessage?.toolUses ?? []
       const toolUseIds = toolUses.map((tu, idx) => tu.toolUseId ?? `toolUse_${idx + 1}`)
-      
+
       if (!nextMessage || !isUserInputMessage(nextMessage) || !hasToolResults(nextMessage)) {
         // 没有对应的工具结果，添加失败消息
         result.push(createFailedToolUseMessage(toolUseIds))
-      } else if (!hasMatchingToolResults(
-        message.assistantResponseMessage?.toolUses,
-        nextMessage.userInputMessage?.userInputMessageContext?.toolResults
-      ) && !messages.some((candidate, index) => (
-        index !== i
-        && isAssistantResponseMessage(candidate)
-        && hasToolUses(candidate)
-        && hasMatchingToolResults(candidate.assistantResponseMessage?.toolUses, nextMessage.userInputMessage?.userInputMessageContext?.toolResults)
-      ))) {
+      } else if (
+        !hasMatchingToolResults(
+          message.assistantResponseMessage?.toolUses,
+          nextMessage.userInputMessage?.userInputMessageContext?.toolResults
+        ) &&
+        !messages.some(
+          (candidate, index) =>
+            index !== i &&
+            isAssistantResponseMessage(candidate) &&
+            hasToolUses(candidate) &&
+            hasMatchingToolResults(
+              candidate.assistantResponseMessage?.toolUses,
+              nextMessage.userInputMessage?.userInputMessageContext?.toolResults
+            )
+        )
+      ) {
         // 工具结果不匹配，添加失败消息
-        const existingToolResults = nextMessage.userInputMessage?.userInputMessageContext?.toolResults ?? []
+        const existingToolResults =
+          nextMessage.userInputMessage?.userInputMessageContext?.toolResults ?? []
         const validToolUseIds = new Set(toolUseIds)
         const usedToolUseIds = new Set<string>()
-        const completedToolResults = existingToolResults.filter(toolResult => {
-          if (!toolResult.toolUseId || !validToolUseIds.has(toolResult.toolUseId) || usedToolUseIds.has(toolResult.toolUseId)) return false
+        const completedToolResults = existingToolResults.filter((toolResult) => {
+          if (
+            !toolResult.toolUseId ||
+            !validToolUseIds.has(toolResult.toolUseId) ||
+            usedToolUseIds.has(toolResult.toolUseId)
+          )
+            return false
           usedToolUseIds.add(toolResult.toolUseId)
           return true
         })
         for (const toolUseId of toolUseIds) {
-          if (!usedToolUseIds.has(toolUseId)) completedToolResults.push(createFailedToolResult(toolUseId))
+          if (!usedToolUseIds.has(toolUseId))
+            completedToolResults.push(createFailedToolResult(toolUseId))
         }
         result.push({
           userInputMessage: {
@@ -647,7 +829,7 @@ function ensureValidToolUsesAndResults(messages: KiroHistoryMessage[]): KiroHist
 // 移除空的 user 消息
 function removeEmptyUserMessages(messages: KiroHistoryMessage[]): KiroHistoryMessage[] {
   if (messages.length <= 1) return messages
-  
+
   const firstUserMessageIndex = messages.findIndex(isUserInputMessage)
   return messages.filter((message, index) => {
     if (isAssistantResponseMessage(message)) return true
@@ -683,11 +865,24 @@ function validateConversation(messages: KiroHistoryMessage[]): string[] {
   for (let i = 0; i < messages.length - 1; i++) {
     const message = messages[i]
     const nextMessage = messages[i + 1]
-    if (isAssistantResponseMessage(message) && hasToolUses(message) && (!isUserInputMessage(nextMessage) || !hasMatchingToolResults(message.assistantResponseMessage?.toolUses, nextMessage?.userInputMessage?.userInputMessageContext?.toolResults))) {
+    if (
+      isAssistantResponseMessage(message) &&
+      hasToolUses(message) &&
+      (!isUserInputMessage(nextMessage) ||
+        !hasMatchingToolResults(
+          message.assistantResponseMessage?.toolUses,
+          nextMessage?.userInputMessage?.userInputMessageContext?.toolResults
+        ))
+    ) {
       errors.push(`TOOL_USES_AND_RESULTS:index=${i + 1}`)
       break
     }
-    if (isAssistantResponseMessage(message) && !hasToolUses(message) && isUserInputMessage(nextMessage) && hasToolResults(nextMessage)) {
+    if (
+      isAssistantResponseMessage(message) &&
+      !hasToolUses(message) &&
+      isUserInputMessage(nextMessage) &&
+      hasToolResults(nextMessage)
+    ) {
       errors.push(`TOOL_RESULTS_AND_NO_USES:index=${i}`)
       break
     }
@@ -695,11 +890,28 @@ function validateConversation(messages: KiroHistoryMessage[]): string[] {
   for (let i = 1; i < messages.length; i++) {
     const previousMessage = messages[i - 1]
     const currentMessage = messages[i]
-    if (!isAssistantResponseMessage(previousMessage) || !hasToolUses(previousMessage) || !isUserInputMessage(currentMessage) || !hasToolResults(currentMessage)) continue
-    const toolUseIds = new Set((previousMessage.assistantResponseMessage?.toolUses ?? []).map(toolUse => toolUse.toolUseId).filter(Boolean))
+    if (
+      !isAssistantResponseMessage(previousMessage) ||
+      !hasToolUses(previousMessage) ||
+      !isUserInputMessage(currentMessage) ||
+      !hasToolResults(currentMessage)
+    )
+      continue
+    const toolUseIds = new Set(
+      (previousMessage.assistantResponseMessage?.toolUses ?? [])
+        .map((toolUse) => toolUse.toolUseId)
+        .filter(Boolean)
+    )
     const seenToolUseIds = new Set<string>()
-    const hasInvalidToolResult = (currentMessage.userInputMessage?.userInputMessageContext?.toolResults ?? []).some(toolResult => {
-      if (!toolResult.toolUseId || !toolUseIds.has(toolResult.toolUseId) || seenToolUseIds.has(toolResult.toolUseId)) return true
+    const hasInvalidToolResult = (
+      currentMessage.userInputMessage?.userInputMessageContext?.toolResults ?? []
+    ).some((toolResult) => {
+      if (
+        !toolResult.toolUseId ||
+        !toolUseIds.has(toolResult.toolUseId) ||
+        seenToolUseIds.has(toolResult.toolUseId)
+      )
+        return true
       seenToolUseIds.add(toolResult.toolUseId)
       return false
     })
@@ -710,7 +922,11 @@ function validateConversation(messages: KiroHistoryMessage[]): string[] {
   }
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i]
-    if (isUserInputMessage(message) && !message.userInputMessage?.content?.trim() && !hasToolResults(message)) {
+    if (
+      isUserInputMessage(message) &&
+      !message.userInputMessage?.content?.trim() &&
+      !hasToolResults(message)
+    ) {
       errors.push(`NON_EMPTY_USER_MESSAGE:index=${i}`)
       break
     }
@@ -719,7 +935,9 @@ function validateConversation(messages: KiroHistoryMessage[]): string[] {
 }
 
 function getToolNames(tools: KiroToolWrapper[]): Set<string> {
-  return new Set(tools.flatMap(tool => 'toolSpecification' in tool ? [tool.toolSpecification.name] : []))
+  return new Set(
+    tools.flatMap((tool) => ('toolSpecification' in tool ? [tool.toolSpecification.name] : []))
+  )
 }
 
 function stringifyToolInput(input: unknown): string {
@@ -740,34 +958,54 @@ function flattenContent(content: string, extra: string): string {
 }
 
 function formatToolUses(toolUses: KiroToolUse[]): string {
-  return toolUses.map(toolUse => [
-    `<tool_use id="${toolUse.toolUseId}" name="${toolUse.name}">`,
-    stringifyToolInput(toolUse.input),
-    '</tool_use>'
-  ].filter(Boolean).join('\n')).join('\n\n')
+  return toolUses
+    .map((toolUse) =>
+      [
+        `<tool_use id="${toolUse.toolUseId}" name="${toolUse.name}">`,
+        stringifyToolInput(toolUse.input),
+        '</tool_use>'
+      ]
+        .filter(Boolean)
+        .join('\n')
+    )
+    .join('\n\n')
 }
 
 function formatToolResults(toolResults: KiroToolResult[]): string {
-  return toolResults.map(toolResult => [
-    `<tool_result id="${toolResult.toolUseId}" status="${toolResult.status}">`,
-    toolResult.content.map(content => content.text).join('\n'),
-    '</tool_result>'
-  ].filter(Boolean).join('\n')).join('\n\n')
+  return toolResults
+    .map((toolResult) =>
+      [
+        `<tool_result id="${toolResult.toolUseId}" status="${toolResult.status}">`,
+        toolResult.content.map((content) => content.text).join('\n'),
+        '</tool_result>'
+      ]
+        .filter(Boolean)
+        .join('\n')
+    )
+    .join('\n\n')
 }
 
-function normalizeToolHistory(messages: KiroHistoryMessage[], tools: KiroToolWrapper[]): KiroHistoryMessage[] {
+function normalizeToolHistory(
+  messages: KiroHistoryMessage[],
+  tools: KiroToolWrapper[]
+): KiroHistoryMessage[] {
   const toolNames = getToolNames(tools)
-  const hasUnknownToolUse = messages.some(message => (
-    message.assistantResponseMessage?.toolUses?.some(toolUse => !toolNames.has(toolUse.name)) ?? false
-  ))
+  const hasUnknownToolUse = messages.some(
+    (message) =>
+      message.assistantResponseMessage?.toolUses?.some((toolUse) => !toolNames.has(toolUse.name)) ??
+      false
+  )
   if (!hasUnknownToolUse) return messages
 
-  return messages.map(message => {
+  return messages.map((message) => {
     if (message.assistantResponseMessage?.toolUses?.length) {
       return {
         assistantResponseMessage: {
           ...message.assistantResponseMessage,
-          content: flattenContent(message.assistantResponseMessage.content, formatToolUses(message.assistantResponseMessage.toolUses)),
+          content: flattenContent(
+            message.assistantResponseMessage.content,
+            formatToolUses(message.assistantResponseMessage.toolUses)
+          ),
           toolUses: undefined
         }
       }
@@ -776,7 +1014,10 @@ function normalizeToolHistory(messages: KiroHistoryMessage[], tools: KiroToolWra
       return {
         userInputMessage: {
           ...message.userInputMessage,
-          content: flattenContent(message.userInputMessage.content, formatToolResults(message.userInputMessage.userInputMessageContext.toolResults)),
+          content: flattenContent(
+            message.userInputMessage.content,
+            formatToolResults(message.userInputMessage.userInputMessageContext.toolResults)
+          ),
           userInputMessageContext: {
             ...message.userInputMessage.userInputMessageContext,
             toolResults: undefined
@@ -808,7 +1049,10 @@ function sanitizeConversation(messages: KiroHistoryMessage[]): KiroHistoryMessag
 // 按 token 估算成对裁剪 history 最旧消息 (避免后端 CONTENT_LENGTH_EXCEEDS_THRESHOLD)
 // 切点保证不破坏 toolUse↔toolResult 配对：assistant(toolUse) 必须连同后续 user(toolResult) 一起裁
 // 裁剪后用 ensureStartsWithUserMessage 兜底重新规范化
-function trimHistoryByTokens(payload: KiroPayload, maxTokens: number): { trimmed: number; finalTokens: number; iterations: number } {
+function trimHistoryByTokens(
+  payload: KiroPayload,
+  maxTokens: number
+): { trimmed: number; finalTokens: number; iterations: number } {
   let history = payload.conversationState.history
   if (!history || history.length === 0) {
     return { trimmed: 0, finalTokens: estimatePayloadTokens(payload), iterations: 0 }
@@ -860,12 +1104,18 @@ export function buildKiroPayload(
   images: KiroImage[] = [],
   profileArn?: string,
   inferenceConfig?: { maxTokens?: number; temperature?: number; topP?: number },
-  messageOptions?: { cachePoint?: KiroCachePoint | undefined; clientCacheConfig?: unknown; documents?: KiroDocument[]; conversationId?: string; context?: KiroRequestContext },
+  messageOptions?: {
+    cachePoint?: KiroCachePoint | undefined
+    clientCacheConfig?: unknown
+    documents?: KiroDocument[]
+    conversationId?: string
+    context?: KiroRequestContext
+  },
   additionalModelRequestFields?: Record<string, unknown>
 ): KiroPayload {
   // 构建当前消息
   const finalContent = content.trim() || (toolResults.length > 0 ? '' : 'Continue')
-  
+
   const currentUserInputMessage: KiroUserInputMessage = {
     content: finalContent,
     modelId,
@@ -903,11 +1153,21 @@ export function buildKiroPayload(
   if (messageOptions?.context) {
     currentUserInputMessage.userInputMessageContext = {
       ...currentUserInputMessage.userInputMessageContext,
-      ...(messageOptions.context.editorState !== undefined ? { editorState: messageOptions.context.editorState } : {}),
-      ...(messageOptions.context.shellState !== undefined ? { shellState: messageOptions.context.shellState } : {}),
-      ...(messageOptions.context.gitState !== undefined ? { gitState: messageOptions.context.gitState } : {}),
-      ...(messageOptions.context.envState !== undefined ? { envState: messageOptions.context.envState } : {}),
-      ...(messageOptions.context.additionalContext !== undefined ? { additionalContext: messageOptions.context.additionalContext } : {})
+      ...(messageOptions.context.editorState !== undefined
+        ? { editorState: messageOptions.context.editorState }
+        : {}),
+      ...(messageOptions.context.shellState !== undefined
+        ? { shellState: messageOptions.context.shellState }
+        : {}),
+      ...(messageOptions.context.gitState !== undefined
+        ? { gitState: messageOptions.context.gitState }
+        : {}),
+      ...(messageOptions.context.envState !== undefined
+        ? { envState: messageOptions.context.envState }
+        : {}),
+      ...(messageOptions.context.additionalContext !== undefined
+        ? { additionalContext: messageOptions.context.additionalContext }
+        : {})
     }
   }
 
@@ -919,7 +1179,7 @@ export function buildKiroPayload(
   // 清理并准备所有消息（history + currentMessage）
   const allMessages = [...history, currentMessage]
   const sanitizedMessages = sanitizeConversation(normalizeToolHistory(allMessages, tools))
-  
+
   // 分离 history 和 currentMessage
   // currentMessage 是最后一条消息，history 是其余的
   const sanitizedHistory = sanitizedMessages.slice(0, -1)
@@ -937,7 +1197,7 @@ export function buildKiroPayload(
       }
     }
   }
-  
+
   finalCurrentMessage.userInputMessage!.userInputMessageContext = {
     ...finalCurrentMessage.userInputMessage!.userInputMessageContext,
     ...(tools.length > 0 ? { tools } : {})
@@ -963,7 +1223,12 @@ export function buildKiroPayload(
     payload.profileArn = profileArn
   }
 
-  if (inferenceConfig && (inferenceConfig.maxTokens || inferenceConfig.temperature !== undefined || inferenceConfig.topP !== undefined)) {
+  if (
+    inferenceConfig &&
+    (inferenceConfig.maxTokens ||
+      inferenceConfig.temperature !== undefined ||
+      inferenceConfig.topP !== undefined)
+  ) {
     payload.inferenceConfig = {}
     if (inferenceConfig.maxTokens) {
       payload.inferenceConfig.maxTokens = inferenceConfig.maxTokens
@@ -992,7 +1257,9 @@ export function buildKiroPayload(
     const tokenTrimResult = trimHistoryByTokens(payload, effectiveTokenLimit)
     if (tokenTrimResult.trimmed > 0) {
       const modelCtx = getModelContextLength(modelId)
-      console.log(`[KiroPayload] Trimmed ${tokenTrimResult.trimmed} oldest history messages by token estimate (≈${tokenTrimResult.finalTokens.toLocaleString()} / ${effectiveTokenLimit.toLocaleString()} tokens [model ctx ${modelCtx.toLocaleString()} - buffer ${tokenBufferReserve.toLocaleString()}], ${tokenTrimResult.iterations} iter)`)
+      console.log(
+        `[KiroPayload] Trimmed ${tokenTrimResult.trimmed} oldest history messages by token estimate (≈${tokenTrimResult.finalTokens.toLocaleString()} / ${effectiveTokenLimit.toLocaleString()} tokens [model ctx ${modelCtx.toLocaleString()} - buffer ${tokenBufferReserve.toLocaleString()}], ${tokenTrimResult.iterations} iter)`
+      )
     }
   }
 
@@ -1024,7 +1291,9 @@ export function buildKiroPayload(
       }
     }
     if (truncatedCount > 0) {
-      console.log(`[KiroPayload] Truncated ${truncatedCount} large tool results to fit payload size limit (final size: ${initialPayloadSize} bytes)`)
+      console.log(
+        `[KiroPayload] Truncated ${truncatedCount} large tool results to fit payload size limit (final size: ${initialPayloadSize} bytes)`
+      )
     }
   }
 
@@ -1077,11 +1346,14 @@ function resolveConversationId(history: KiroHistoryMessage[], sessionHint?: stri
 
 function fingerprintFromHistory(history: KiroHistoryMessage[]): string | undefined {
   if (history.length === 0) return undefined
-  const fp = history.slice(0, 2).map(msg =>
-    `${msg.userInputMessage?.content || ''}|${msg.assistantResponseMessage?.content || ''}`
-  ).join('::')
-  const crypto = require('crypto')
-  return crypto.createHash('sha256').update(fp).digest('hex').slice(0, 32)
+  const fp = history
+    .slice(0, 2)
+    .map(
+      (msg) =>
+        `${msg.userInputMessage?.content || ''}|${msg.assistantResponseMessage?.content || ''}`
+    )
+    .join('::')
+  return createHash('sha256').update(fp).digest('hex').slice(0, 32)
 }
 
 // 清除所有内存缓存
@@ -1099,8 +1371,7 @@ const fallbackMachineIds = new Map<string, string>()
 function generateStableMachineId(accountId: string): string {
   const cached = fallbackMachineIds.get(accountId)
   if (cached) return cached
-  const crypto = require('crypto')
-  const hash = crypto.createHash('sha256').update(`kiro-device-${accountId}`).digest('hex')
+  const hash = createHash('sha256').update(`kiro-device-${accountId}`).digest('hex')
   fallbackMachineIds.set(accountId, hash)
   return hash
 }
@@ -1117,41 +1388,58 @@ function getAccountMachineId(accountId: string, accountMachineId?: string): stri
 }
 
 // 获取认证方式对应的请求头
-function getAuthHeaders(account: ProxyAccount, _endpoint: typeof KIRO_ENDPOINTS[0]): Record<string, string> {
+function getAuthHeaders(account: ProxyAccount, endpoint: KiroEndpoint): Record<string, string> {
   const isIDC = account.authMethod?.toLowerCase() === 'idc'
   const machineId = getAccountMachineId(account.id, account.machineId)
-  const agentMode = isIDC ? AGENT_MODE_VIBE : AGENT_MODE_SPEC
-  
+  const isRpcJson = endpoint.protocol === 'rpcJson'
+  const useCliUserAgent = isRpcJson || (!isEnterpriseProvider(account.provider) && isIDC)
+  const agentMode = useCliUserAgent ? AGENT_MODE_VIBE : AGENT_MODE_SPEC
+
   const headers: Record<string, string> = {
-    'content-type': 'application/json',
-    'x-amzn-kiro-agent-mode': agentMode,
-    'x-amz-user-agent': isIDC ? KIRO_CLI_AMZ_USER_AGENT : getKiroAmzUserAgent(machineId),
-    'user-agent': isIDC ? KIRO_CLI_USER_AGENT : getKiroUserAgent(machineId),
+    'content-type': isRpcJson ? 'application/x-amz-json-1.0' : 'application/json',
+    'x-amz-user-agent': useCliUserAgent ? KIRO_CLI_AMZ_USER_AGENT : getKiroAmzUserAgent(machineId),
+    'user-agent': useCliUserAgent ? KIRO_CLI_USER_AGENT : getKiroUserAgent(machineId),
     'amz-sdk-invocation-id': uuidv4(),
     'amz-sdk-request': 'attempt=1; max=3',
-    'Authorization': `Bearer ${account.accessToken}`
+    Authorization: `Bearer ${account.accessToken}`
+  }
+  if (isRpcJson) {
+    headers['x-amz-target'] = endpoint.amzTarget
+    headers['x-amzn-codewhisperer-optout'] = 'false'
+    headers['accept'] = '*/*'
+  } else {
+    headers['x-amzn-kiro-agent-mode'] = agentMode
   }
   return headers
 }
 
 // 获取排序后的端点列表（根据首选端点配置）
-function getSortedEndpoints(preferredEndpoint?: 'codewhisperer' | 'amazonq' | 'amazonq-cli'): typeof KIRO_ENDPOINTS {
-  if (!preferredEndpoint) return KIRO_ENDPOINTS.filter(ep => ep.name !== 'AmazonQCLI')
-  
+function getSortedEndpoints(
+  account: ProxyAccount,
+  preferredEndpoint?: 'codewhisperer' | 'amazonq' | 'amazonq-cli'
+): KiroEndpoint[] {
+  if (isEnterpriseProvider(account.provider)) {
+    return KIRO_ENDPOINTS.filter(
+      (ep) => ep.name === (preferredEndpoint === 'amazonq-cli' ? 'AmazonQCLI' : 'AmazonQ')
+    )
+  }
+
+  if (!preferredEndpoint) return KIRO_ENDPOINTS.filter((ep) => ep.name !== 'AmazonQCLI')
+
   // AmazonQ CLI 模式：只用这一个端点，失败不回退
   if (preferredEndpoint === 'amazonq-cli') {
-    return KIRO_ENDPOINTS.filter(ep => ep.name === 'AmazonQCLI')
+    return KIRO_ENDPOINTS.filter((ep) => ep.name === 'AmazonQCLI')
   }
-  
+
   const preferredName = preferredEndpoint === 'codewhisperer' ? 'CodeWhisperer' : 'AmazonQ'
-  
-  const sorted = KIRO_ENDPOINTS.filter(ep => ep.name !== 'AmazonQCLI')
+
+  const sorted = KIRO_ENDPOINTS.filter((ep) => ep.name !== 'AmazonQCLI')
   sorted.sort((a, b) => {
     if (a.name === preferredName) return -1
     if (b.name === preferredName) return 1
     return 0
   })
-  
+
   return sorted
 }
 
@@ -1169,54 +1457,87 @@ function throwIfAborted(signal?: AbortSignal): void {
 export async function callKiroApiStream(
   account: ProxyAccount,
   payload: KiroPayload,
-  onChunk: (text: string, toolUse?: KiroToolUse, isThinking?: boolean, reasoningSignature?: string, redactedContent?: string) => void,
+  onChunk: (
+    text: string,
+    toolUse?: KiroToolUse,
+    isThinking?: boolean,
+    reasoningSignature?: string,
+    redactedContent?: string
+  ) => void,
   onComplete: (usage: KiroUsage) => void,
   onError: (error: Error) => void,
   signal?: AbortSignal,
   preferredEndpoint?: 'codewhisperer' | 'amazonq' | 'amazonq-cli'
 ): Promise<void> {
-  const endpoints = getSortedEndpoints(preferredEndpoint)
+  const endpoints = getSortedEndpoints(account, preferredEndpoint)
   let lastError: Error | null = null
 
   for (const endpoint of endpoints) {
     try {
       throwIfAborted(signal)
       const requestPayload = clonePayload(payload)
-      requestPayload.profileArn = resolveProfileArn(account)
+      const profileArn = await resolveAccountProfileArn(account, signal)
+      if (profileArn) {
+        requestPayload.profileArn = profileArn
+      } else {
+        delete requestPayload.profileArn
+      }
       const requestedModelId = getPayloadModelId(requestPayload)
       if (endpoint.name === 'CodeWhisperer') {
-        applyPayloadModelId(requestPayload, await resolveCodeWhispererModelId(account, requestedModelId, signal))
+        applyPayloadModelId(
+          requestPayload,
+          await resolveCodeWhispererModelId(account, requestedModelId, signal)
+        )
       }
 
       applyPayloadOrigin(requestPayload, endpoint.origin)
 
-      // AmazonQCLI 端点不支持 agentContinuationId/agentTaskType
+      // AmazonQ CLI 协议不带 agentContinuationId，但保留 agentTaskType=vibe
       if (endpoint.name === 'AmazonQCLI') {
-        delete (requestPayload.conversationState as unknown as Record<string, unknown>).agentContinuationId
-        delete (requestPayload.conversationState as unknown as Record<string, unknown>).agentTaskType
+        delete (requestPayload.conversationState as unknown as Record<string, unknown>)
+          .agentContinuationId
       }
 
       const payloadStr = JSON.stringify(requestPayload)
       const headers = getAuthHeaders(account, endpoint)
       const currentUserInput = requestPayload.conversationState.currentMessage.userInputMessage
       const historyMessages = requestPayload.conversationState.history ?? []
-      const historyToolUseCount = historyMessages.reduce((count, message) => count + (message.assistantResponseMessage?.toolUses?.length ?? 0), 0)
-      const historyToolResultCount = historyMessages.reduce((count, message) => count + (message.userInputMessage?.userInputMessageContext?.toolResults?.length ?? 0), 0)
+      const historyToolUseCount = historyMessages.reduce(
+        (count, message) => count + (message.assistantResponseMessage?.toolUses?.length ?? 0),
+        0
+      )
+      const historyToolResultCount = historyMessages.reduce(
+        (count, message) =>
+          count + (message.userInputMessage?.userInputMessageContext?.toolResults?.length ?? 0),
+        0
+      )
       console.log(`[KiroAPI] Request to ${endpoint.name}:`)
       console.log(`[KiroAPI]   - Content length: ${currentUserInput?.content?.length || 0}`)
-      console.log(`[KiroAPI]   - Tools count: ${currentUserInput?.userInputMessageContext?.tools?.length || 0}`)
-      console.log(`[KiroAPI]   - Current tool results: ${currentUserInput?.userInputMessageContext?.toolResults?.length || 0}`)
+      console.log(
+        `[KiroAPI]   - Tools count: ${currentUserInput?.userInputMessageContext?.tools?.length || 0}`
+      )
+      console.log(
+        `[KiroAPI]   - Current tool results: ${currentUserInput?.userInputMessageContext?.toolResults?.length || 0}`
+      )
       console.log(`[KiroAPI]   - History messages: ${historyMessages.length}`)
-      console.log(`[KiroAPI]   - History tool uses/results: ${historyToolUseCount}/${historyToolResultCount}`)
+      console.log(
+        `[KiroAPI]   - History tool uses/results: ${historyToolUseCount}/${historyToolResultCount}`
+      )
       console.log(`[KiroAPI]   - Model ID: ${currentUserInput?.modelId || 'default'}`)
       console.log(`[KiroAPI]   - Has profileArn: ${requestPayload.profileArn !== undefined}`)
-      console.log(`[KiroAPI]   - Agent mode: ${headers['x-amzn-kiro-agent-mode']}`)
+      console.log(`[KiroAPI]   - Agent mode: ${headers['x-amzn-kiro-agent-mode'] || 'n/a'}`)
       console.log(`[KiroAPI]   - Payload size: ${payloadStr.length} bytes`)
-      
+
       const agent = getNetworkAgent(account)
       if (agent) proxyLogger.debug('KiroAPI', `Stream request via proxy to ${endpoint.name}`)
       const response = agent
-        ? await undiciFetch(endpoint.url, { method: 'POST', headers, body: payloadStr, signal, dispatcher: agent } as UndiciRequestInit) as unknown as Response
+        ? ((await undiciFetch(endpoint.url, {
+            method: 'POST',
+            headers,
+            body: payloadStr,
+            signal,
+            dispatcher: agent
+          } as UndiciRequestInit)) as unknown as Response)
         : await fetch(endpoint.url, { method: 'POST', headers, body: payloadStr, signal })
 
       if (response.status === 429) {
@@ -1229,6 +1550,17 @@ export async function callKiroApiStream(
         throwIfAborted(signal)
         const body = await response.text()
         throwIfAborted(signal)
+        if (
+          response.status === 403 &&
+          endpoint.name === 'CodeWhisperer' &&
+          body.includes('subscription does not support this application')
+        ) {
+          console.log(
+            `[KiroAPI] Endpoint ${endpoint.name} not supported by subscription, trying next...`
+          )
+          lastError = new Error(`Auth error ${response.status}: ${body}`)
+          continue
+        }
         throw new Error(`Auth error ${response.status}: ${body}`)
       }
 
@@ -1242,7 +1574,16 @@ export async function callKiroApiStream(
       // 解析 Event Stream
       // 传入 modelId + payloadStr 用于精确 token 计算（contextUsage 反推 + tiktoken）
       const inputChars = payloadStr.length
-      await parseEventStream(response.body!, onChunk, onComplete, onError, inputChars, signal, requestedModelId, payloadStr)
+      await parseEventStream(
+        response.body!,
+        onChunk,
+        onComplete,
+        onError,
+        inputChars,
+        signal,
+        requestedModelId,
+        payloadStr
+      )
       return
     } catch (error) {
       if (signal?.aborted) {
@@ -1251,7 +1592,7 @@ export async function callKiroApiStream(
       }
       lastError = error as Error
       console.error(`[KiroAPI] Endpoint ${endpoint.name} failed:`, error)
-      
+
       // 如果是认证错误，不继续尝试其他端点
       if ((error as Error).message.includes('Auth error')) {
         onError(error as Error)
@@ -1278,8 +1619,9 @@ function extractEventType(headers: Uint8Array): string {
     if (offset >= headers.length) break
     const valueType = headers[offset]
     offset++
-    
-    if (valueType === 7) { // String type
+
+    if (valueType === 7) {
+      // String type
       if (offset + 2 > headers.length) break
       const valueLen = (headers[offset] << 8) | headers[offset + 1]
       offset += 2
@@ -1291,7 +1633,7 @@ function extractEventType(headers: Uint8Array): string {
       }
       continue
     }
-    
+
     // Skip other value types
     const skipSizes: Record<number, number> = { 0: 0, 1: 0, 2: 1, 3: 2, 4: 4, 5: 8, 8: 8, 9: 16 }
     if (valueType === 6) {
@@ -1323,38 +1665,44 @@ export function estimateTokens(text: string): number {
 // 解析 AWS Event Stream 二进制格式
 async function parseEventStream(
   body: ReadableStream<Uint8Array>,
-  onChunk: (text: string, toolUse?: KiroToolUse, isThinking?: boolean, reasoningSignature?: string, redactedContent?: string) => void,
+  onChunk: (
+    text: string,
+    toolUse?: KiroToolUse,
+    isThinking?: boolean,
+    reasoningSignature?: string,
+    redactedContent?: string
+  ) => void,
   onComplete: (usage: KiroUsage) => void,
   onError: (error: Error) => void,
-  inputChars: number = 0,  // 输入字符长度（兜底估算用）
+  inputChars: number = 0, // 输入字符长度（兜底估算用）
   signal?: AbortSignal,
-  modelId?: string,        // 模型 ID，用于 contextUsagePercentage 反推 inputTokens
-  payloadStr?: string      // 请求 payload JSON 字符串，用于 tiktoken 精确计算
+  modelId?: string, // 模型 ID，用于 contextUsagePercentage 反推 inputTokens
+  payloadStr?: string // 请求 payload JSON 字符串，用于 tiktoken 精确计算
 ): Promise<void> {
   const reader = body.getReader()
-  const abort = () => {
+  const abort = (): void => {
     reader.cancel(getAbortError(signal)).catch(() => undefined)
   }
   let buffer = new Uint8Array(0)
-  let usage = { 
-    inputTokens: 0, 
-    outputTokens: 0, 
+  const usage = {
+    inputTokens: 0,
+    outputTokens: 0,
     credits: 0,
     cacheReadTokens: 0,
     cacheWriteTokens: 0,
     reasoningTokens: 0
   }
-  
+
   // 累积输出文本长度，用于估算 tokens
   let totalOutputChars = 0
   // 累积输出文本内容，用于 tiktoken 精确计算 output tokens
   let collectedOutputText = ''
   // 是否已拿到 Kiro 真实 tokenUsage（最高优先级，锁定后不再被 contextUsage/tiktoken 覆盖）
   let hasRealTokenUsage = false
-  
+
   // 流式事件聚合计数（logStreamEvents 开启时，结束后输出摘要而非逐条输出）
   const streamEventCounts: Record<string, number> = {}
-  
+
   // 初始化 input tokens 估算（优先级链路：tokenUsage > contextUsage 反推 > tiktoken > 字符系数）
   // 这里只是兜底初值，后续真实事件会覆盖
   if (payloadStr) {
@@ -1364,7 +1712,7 @@ async function parseEventStream(
     // 字符系数兜底（针对 payload JSON 经验值 0.42）
     usage.inputTokens = Math.max(1, Math.round(inputChars * 0.42))
   }
-  
+
   // Tool use 状态跟踪 - 用于累积输入片段
   let currentToolUse: ToolUseState | null = null
   const processedIds = new Set<string>()
@@ -1376,7 +1724,7 @@ async function parseEventStream(
       throwIfAborted(signal)
       const { done, value } = await reader.read()
       throwIfAborted(signal)
-      
+
       if (done) {
         break
       }
@@ -1398,29 +1746,29 @@ async function parseEventStream(
         // - 4 bytes: message CRC
 
         const totalLength = new DataView(buffer.buffer, buffer.byteOffset).getUint32(0, false)
-        
+
         if (buffer.length < totalLength) {
           break // 等待更多数据
         }
 
         const headersLength = new DataView(buffer.buffer, buffer.byteOffset).getUint32(4, false)
-        
+
         // 从 headers 中提取 event type
         const headersStart = 12
         const headersEnd = 12 + headersLength
         const eventType = extractEventType(buffer.slice(headersStart, headersEnd))
-        
+
         // 提取 payload
         const payloadStart = 12 + headersLength
         const payloadEnd = totalLength - 4 // 减去 message CRC
-        
+
         if (payloadStart < payloadEnd) {
           const payloadBytes = buffer.slice(payloadStart, payloadEnd)
-          
+
           try {
             const payloadText = new TextDecoder().decode(payloadBytes)
             const event = JSON.parse(payloadText)
-            
+
             // 根据 event type 处理不同类型的事件
             if (eventType === 'assistantResponseEvent' || event.assistantResponseEvent) {
               const assistantResp = event.assistantResponseEvent || event
@@ -1446,13 +1794,13 @@ async function parseEventStream(
                 collectedOutputText += content
               }
             }
-            
+
             if (eventType === 'toolUseEvent' || event.toolUseEvent) {
               const toolUseData = event.toolUseEvent || event
               const toolUseId = toolUseData.toolUseId
               const toolName = toolUseData.name
               const isStop = toolUseData.stop === true
-              
+
               // 获取输入 - 可能是字符串片段或完整对象
               let inputFragment = ''
               let inputObj: Record<string, unknown> | null = null
@@ -1461,7 +1809,7 @@ async function parseEventStream(
               } else if (typeof toolUseData.input === 'object' && toolUseData.input !== null) {
                 inputObj = toolUseData.input
               }
-              
+
               // 新的 tool use 开始
               if (toolUseId && toolName) {
                 if (currentToolUse && currentToolUse.toolUseId !== toolUseId) {
@@ -1472,18 +1820,21 @@ async function parseEventStream(
                       if (currentToolUse.inputBuffer) {
                         finalInput = JSON.parse(currentToolUse.inputBuffer)
                       }
-                    } catch { /* 忽略解析错误 */ }
+                    } catch {
+                      /* 忽略解析错误 */
+                    }
                     onChunk('', {
                       toolUseId: currentToolUse.toolUseId,
                       name: currentToolUse.name,
                       input: finalInput
                     })
-                    totalOutputChars += currentToolUse.name.length + currentToolUse.inputBuffer.length
+                    totalOutputChars +=
+                      currentToolUse.name.length + currentToolUse.inputBuffer.length
                     processedIds.add(currentToolUse.toolUseId)
                   }
                   currentToolUse = null
                 }
-                
+
                 if (!currentToolUse) {
                   if (processedIds.has(toolUseId)) {
                     // 跳过重复的 tool use
@@ -1496,30 +1847,43 @@ async function parseEventStream(
                   }
                 }
               }
-              
+
               // 累积输入片段
               if (currentToolUse && inputFragment) {
                 currentToolUse.inputBuffer += inputFragment
               }
-              
+
               // 如果直接提供了完整输入对象
               if (currentToolUse && inputObj) {
                 currentToolUse.inputBuffer = JSON.stringify(inputObj)
               }
-              
+
               // Tool use 完成
               if (isStop && currentToolUse) {
                 let finalInput: Record<string, unknown> = {}
                 let parseError = false
                 try {
                   if (currentToolUse.inputBuffer) {
-                    if (logStreamEvents) proxyLogger.debug('Kiro', 'Tool input buffer: ' + currentToolUse.inputBuffer.substring(0, 200))
+                    if (logStreamEvents)
+                      proxyLogger.debug(
+                        'Kiro',
+                        'Tool input buffer: ' + currentToolUse.inputBuffer.substring(0, 200)
+                      )
                     finalInput = JSON.parse(currentToolUse.inputBuffer)
-                    if (logStreamEvents) proxyLogger.debug('Kiro', 'Parsed tool input: ' + JSON.stringify(finalInput).substring(0, 200))
+                    if (logStreamEvents)
+                      proxyLogger.debug(
+                        'Kiro',
+                        'Parsed tool input: ' + JSON.stringify(finalInput).substring(0, 200)
+                      )
                   }
                 } catch (e) {
                   parseError = true
-                  console.error('[Kiro] Failed to parse tool input:', e, 'Buffer:', currentToolUse.inputBuffer?.substring(0, 100))
+                  console.error(
+                    '[Kiro] Failed to parse tool input:',
+                    e,
+                    'Buffer:',
+                    currentToolUse.inputBuffer?.substring(0, 100)
+                  )
                   // 当 JSON 解析失败时，创建一个包含错误信息的 input
                   // 这样客户端可以看到工具调用失败的原因
                   finalInput = {
@@ -1527,7 +1891,7 @@ async function parseEventStream(
                     _partialInput: currentToolUse.inputBuffer?.substring(0, 500) || ''
                   }
                 }
-                
+
                 // 只有在成功解析或有错误信息时才发送
                 onChunk('', {
                   toolUseId: currentToolUse.toolUseId,
@@ -1535,22 +1899,29 @@ async function parseEventStream(
                   input: finalInput
                 })
                 totalOutputChars += currentToolUse.name.length + currentToolUse.inputBuffer.length
-                
+
                 // 如果解析失败，额外发送一条文本消息告知用户
                 if (parseError) {
-                  onChunk(`\n\n⚠️ Tool "${currentToolUse.name}" input was truncated by Kiro API. The output may be incomplete due to token limits.`)
+                  onChunk(
+                    `\n\n⚠️ Tool "${currentToolUse.name}" input was truncated by Kiro API. The output may be incomplete due to token limits.`
+                  )
                 }
-                
+
                 processedIds.add(currentToolUse.toolUseId)
                 currentToolUse = null
               }
             }
-            
+
             // 处理 messageMetadataEvent - 包含 token 使用量
-            if (eventType === 'messageMetadataEvent' || eventType === 'metadataEvent' || event.messageMetadataEvent || event.metadataEvent) {
+            if (
+              eventType === 'messageMetadataEvent' ||
+              eventType === 'metadataEvent' ||
+              event.messageMetadataEvent ||
+              event.metadataEvent
+            ) {
               const metadata = event.messageMetadataEvent || event.metadataEvent || event
               proxyLogger.info('Kiro', 'messageMetadataEvent', metadata)
-              
+
               // 检查 tokenUsage 对象
               if (metadata.tokenUsage) {
                 const tokenUsage = metadata.tokenUsage
@@ -1560,10 +1931,10 @@ async function parseEventStream(
                 const cacheRead = tokenUsage.cacheReadInputTokens || 0
                 const cacheWrite = tokenUsage.cacheWriteInputTokens || 0
                 const calculatedInput = uncached + cacheRead + cacheWrite
-                
+
                 if (calculatedInput > 0) {
                   usage.inputTokens = calculatedInput
-                  hasRealTokenUsage = true  // 真实值，锁定不再被 contextUsage/tiktoken 覆盖
+                  hasRealTokenUsage = true // 真实值，锁定不再被 contextUsage/tiktoken 覆盖
                 }
                 if (tokenUsage.outputTokens) usage.outputTokens = tokenUsage.outputTokens
                 if (tokenUsage.totalTokens) {
@@ -1573,16 +1944,19 @@ async function parseEventStream(
                     hasRealTokenUsage = true
                   }
                 }
-                
+
                 // 保存 cache tokens
                 usage.cacheReadTokens = cacheRead
                 usage.cacheWriteTokens = cacheWrite
-                
+
                 // 记录上下文使用百分比
                 if (tokenUsage.contextUsagePercentage !== undefined) {
-                  proxyLogger.info('Kiro', 'Context usage: ' + tokenUsage.contextUsagePercentage.toFixed(2) + '%')
+                  proxyLogger.info(
+                    'Kiro',
+                    'Context usage: ' + tokenUsage.contextUsagePercentage.toFixed(2) + '%'
+                  )
                 }
-                
+
                 // 详细的 token 分解日志
                 proxyLogger.info('Kiro', 'Token breakdown', {
                   uncached,
@@ -1591,10 +1965,12 @@ async function parseEventStream(
                   inputTotal: calculatedInput,
                   output: tokenUsage.outputTokens || 0,
                   total: tokenUsage.totalTokens || 0,
-                  contextUsage: tokenUsage.contextUsagePercentage ? `${tokenUsage.contextUsagePercentage.toFixed(2)}%` : 'N/A'
+                  contextUsage: tokenUsage.contextUsagePercentage
+                    ? `${tokenUsage.contextUsagePercentage.toFixed(2)}%`
+                    : 'N/A'
                 })
               }
-              
+
               // 直接在 metadata 中的 tokens
               if (metadata.inputTokens) {
                 usage.inputTokens = metadata.inputTokens
@@ -1602,14 +1978,20 @@ async function parseEventStream(
               }
               if (metadata.outputTokens) usage.outputTokens = metadata.outputTokens
             }
-            
+
             if (logStreamEvents) {
               // 聚合流式事件（不逐条输出，在 onComplete 时输出摘要）
-              streamEventCounts[eventType || 'unknown'] = (streamEventCounts[eventType || 'unknown'] || 0) + 1
+              streamEventCounts[eventType || 'unknown'] =
+                (streamEventCounts[eventType || 'unknown'] || 0) + 1
             }
-            
+
             // 处理 usageEvent
-            if (eventType === 'usageEvent' || eventType === 'usage' || event.usageEvent || event.usage) {
+            if (
+              eventType === 'usageEvent' ||
+              eventType === 'usage' ||
+              event.usageEvent ||
+              event.usage
+            ) {
               const usageData = event.usageEvent || event.usage || event
               if (usageData.inputTokens) {
                 usage.inputTokens = usageData.inputTokens
@@ -1617,21 +1999,27 @@ async function parseEventStream(
               }
               if (usageData.outputTokens) usage.outputTokens = usageData.outputTokens
             }
-            
+
             // 处理 meteringEvent - Kiro API 返回 credit 使用量
             if (eventType === 'meteringEvent' || event.meteringEvent) {
               const metering = event.meteringEvent || event
               if (metering.usage && typeof metering.usage === 'number') {
                 // 累加 credit 使用量
                 usage.credits += metering.usage
-                proxyLogger.info('Kiro', `meteringEvent - credit: ${metering.usage}, total: ${usage.credits}`)
+                proxyLogger.info(
+                  'Kiro',
+                  `meteringEvent - credit: ${metering.usage}, total: ${usage.credits}`
+                )
               }
             }
-            
+
             // 处理 supplementaryWebLinksEvent - 网页链接引用
             if (eventType === 'supplementaryWebLinksEvent' || event.supplementaryWebLinksEvent) {
               const webLinksEvent = event.supplementaryWebLinksEvent || event
-              if (webLinksEvent.supplementaryWebLinks && Array.isArray(webLinksEvent.supplementaryWebLinks)) {
+              if (
+                webLinksEvent.supplementaryWebLinks &&
+                Array.isArray(webLinksEvent.supplementaryWebLinks)
+              ) {
                 // 格式化网页链接引用
                 const links = webLinksEvent.supplementaryWebLinks
                   .filter((link: { url?: string; title?: string; snippet?: string }) => link.url)
@@ -1643,9 +2031,13 @@ async function parseEventStream(
                   onChunk(`\n\n🔗 **Web References:**\n${links.join('\n')}`)
                 }
               }
-              proxyLogger.debug('Kiro', 'supplementaryWebLinksEvent', JSON.stringify(webLinksEvent).slice(0, 300))
+              proxyLogger.debug(
+                'Kiro',
+                'supplementaryWebLinksEvent',
+                JSON.stringify(webLinksEvent).slice(0, 300)
+              )
             }
-            
+
             // 处理 contextUsageEvent - 上下文使用百分比（反推真实 inputTokens）
             if (eventType === 'contextUsageEvent' || event.contextUsageEvent) {
               const contextEvent = event.contextUsageEvent || event
@@ -1653,31 +2045,46 @@ async function parseEventStream(
                 const percentage = contextEvent.contextUsagePercentage
                 // 若已拿到真实 tokenUsage，仅记录百分比，不覆盖 inputTokens
                 if (hasRealTokenUsage) {
-                  proxyLogger.info('Kiro', `contextUsageEvent - Context usage: ${percentage.toFixed(2)}% (real tokenUsage already received)`)
+                  proxyLogger.info(
+                    'Kiro',
+                    `contextUsageEvent - Context usage: ${percentage.toFixed(2)}% (real tokenUsage already received)`
+                  )
                 } else {
                   // 反推真实 inputTokens：modelContext × percentage / 100
                   const contextLen = getModelContextLength(modelId)
-                  const reverseInput = Math.round(contextLen * percentage / 100)
+                  const reverseInput = Math.round((contextLen * percentage) / 100)
                   if (reverseInput > 0) {
                     usage.inputTokens = reverseInput
-                    proxyLogger.info('Kiro', `contextUsageEvent ${percentage.toFixed(2)}% → inputTokens=${reverseInput} (modelContext=${contextLen}, model=${modelId || 'unknown'})`)
+                    proxyLogger.info(
+                      'Kiro',
+                      `contextUsageEvent ${percentage.toFixed(2)}% → inputTokens=${reverseInput} (modelContext=${contextLen}, model=${modelId || 'unknown'})`
+                    )
                   } else {
-                    proxyLogger.info('Kiro', `contextUsageEvent - Context usage: ${percentage.toFixed(2)}%`)
+                    proxyLogger.info(
+                      'Kiro',
+                      `contextUsageEvent - Context usage: ${percentage.toFixed(2)}%`
+                    )
                   }
                 }
                 // 如果上下文使用率超过 80%，发送警告
                 if (percentage > 80) {
-                  console.warn('[Kiro] Warning: Context usage is high:', percentage.toFixed(2) + '%')
+                  console.warn(
+                    '[Kiro] Warning: Context usage is high:',
+                    percentage.toFixed(2) + '%'
+                  )
                 }
               }
             }
-            
+
             // 处理 reasoningContentEvent - Thinking 模式的推理内容
             // Kiro ReasoningContentEvent 字段：[text, redactedContent, signature]
             if (eventType === 'reasoningContentEvent' || event.reasoningContentEvent) {
               const reasoning = event.reasoningContentEvent || event
               if (reasoning.text) {
-                proxyLogger.info('Kiro', `Received reasoning content (isThinking=true): ${reasoning.text.slice(0, 50)}...`)
+                proxyLogger.info(
+                  'Kiro',
+                  `Received reasoning content (isThinking=true): ${reasoning.text.slice(0, 50)}...`
+                )
                 onChunk(reasoning.text, undefined, true, reasoning.signature, undefined)
                 totalOutputChars += reasoning.text.length
                 usage.reasoningTokens += Math.max(1, Math.round(reasoning.text.length * 0.4))
@@ -1686,19 +2093,29 @@ async function parseEventStream(
               }
               // 处理 redactedContent（重编辑的加密 thinking 内容）
               if (reasoning.redactedContent) {
-                proxyLogger.info('Kiro', `Received redacted thinking content (len=${reasoning.redactedContent.length})`)
+                proxyLogger.info(
+                  'Kiro',
+                  `Received redacted thinking content (len=${reasoning.redactedContent.length})`
+                )
                 onChunk('', undefined, true, undefined, reasoning.redactedContent)
               }
-              proxyLogger.debug('Kiro', 'reasoningContentEvent', JSON.stringify(reasoning).slice(0, 200))
+              proxyLogger.debug(
+                'Kiro',
+                'reasoningContentEvent',
+                JSON.stringify(reasoning).slice(0, 200)
+              )
             }
-            
+
             // 处理 codeReferenceEvent - 代码引用/许可证信息
             if (eventType === 'codeReferenceEvent' || event.codeReferenceEvent) {
               const codeRef = event.codeReferenceEvent || event
               if (codeRef.references && Array.isArray(codeRef.references)) {
                 // 格式化代码引用信息
                 const refTexts = codeRef.references
-                  .filter((ref: { licenseName?: string; repository?: string; url?: string }) => ref.licenseName || ref.repository)
+                  .filter(
+                    (ref: { licenseName?: string; repository?: string; url?: string }) =>
+                      ref.licenseName || ref.repository
+                  )
                   .map((ref: { licenseName?: string; repository?: string; url?: string }) => {
                     const parts: string[] = []
                     if (ref.licenseName) parts.push(`License: ${ref.licenseName}`)
@@ -1712,7 +2129,7 @@ async function parseEventStream(
               }
               proxyLogger.debug('Kiro', 'codeReferenceEvent', JSON.stringify(codeRef).slice(0, 300))
             }
-            
+
             // 处理 followupPromptEvent - 后续提示建议
             if (eventType === 'followupPromptEvent' || event.followupPromptEvent) {
               const followup = event.followupPromptEvent || event
@@ -1724,23 +2141,31 @@ async function parseEventStream(
                   onChunk(`\n\n💡 **Suggested follow-up:** ${suggestion}`)
                 }
               }
-              proxyLogger.debug('Kiro', 'followupPromptEvent', JSON.stringify(followup).slice(0, 200))
+              proxyLogger.debug(
+                'Kiro',
+                'followupPromptEvent',
+                JSON.stringify(followup).slice(0, 200)
+              )
             }
-            
+
             // 处理 intentsEvent - 意图事件（artifact、deeplinks 等）
             if (eventType === 'intentsEvent' || event.intentsEvent) {
               const intents = event.intentsEvent || event
               // 意图事件主要用于 UI 渲染，记录日志即可
               proxyLogger.debug('Kiro', 'intentsEvent', JSON.stringify(intents).slice(0, 300))
             }
-            
+
             // 处理 interactionComponentsEvent - 交互组件事件
             if (eventType === 'interactionComponentsEvent' || event.interactionComponentsEvent) {
               const components = event.interactionComponentsEvent || event
               // 交互组件主要用于 UI 渲染，记录日志即可
-              proxyLogger.debug('Kiro', 'interactionComponentsEvent', JSON.stringify(components).slice(0, 300))
+              proxyLogger.debug(
+                'Kiro',
+                'interactionComponentsEvent',
+                JSON.stringify(components).slice(0, 300)
+              )
             }
-            
+
             // 处理 invalidStateEvent - 无效状态事件（错误处理）
             if (eventType === 'invalidStateEvent' || event.invalidStateEvent) {
               const invalid = event.invalidStateEvent || event
@@ -1750,14 +2175,16 @@ async function parseEventStream(
               // 将无效状态作为错误消息输出
               onChunk(`\n\n⚠️ **Warning:** ${message} (reason: ${reason})`)
             }
-            
+
             // 处理 citationEvent - 引用事件
             if (eventType === 'citationEvent' || event.citationEvent) {
               const citation = event.citationEvent || event
               if (citation.citations && Array.isArray(citation.citations)) {
                 // 格式化引用信息
                 const citationTexts = citation.citations
-                  .filter((c: { title?: string; url?: string; content?: string }) => c.title || c.url)
+                  .filter(
+                    (c: { title?: string; url?: string; content?: string }) => c.title || c.url
+                  )
                   .map((c: { title?: string; url?: string; content?: string }, i: number) => {
                     const parts = [`[${i + 1}]`]
                     if (c.title) parts.push(c.title)
@@ -1770,7 +2197,7 @@ async function parseEventStream(
               }
               proxyLogger.debug('Kiro', 'citationEvent', JSON.stringify(citation).slice(0, 300))
             }
-            
+
             // 检查错误
             if (event._type || event.error) {
               const errMsg = event.message || event.error?.message || 'Unknown stream error'
@@ -1785,12 +2212,12 @@ async function parseEventStream(
             }
           }
         }
-        
+
         // 移动到下一条消息
         buffer = buffer.slice(totalLength)
       }
     }
-    
+
     // 完成任何未完成的 tool use
     if (currentToolUse && !processedIds.has(currentToolUse.toolUseId)) {
       let finalInput: Record<string, unknown> = {}
@@ -1798,7 +2225,9 @@ async function parseEventStream(
         if (currentToolUse.inputBuffer) {
           finalInput = JSON.parse(currentToolUse.inputBuffer)
         }
-      } catch { /* 忽略解析错误 */ }
+      } catch {
+        /* 忽略解析错误 */
+      }
       onChunk('', {
         toolUseId: currentToolUse.toolUseId,
         name: currentToolUse.name,
@@ -1806,31 +2235,37 @@ async function parseEventStream(
       })
       totalOutputChars += currentToolUse.name.length + currentToolUse.inputBuffer.length
     }
-    
+
     // 如果 API 没有返回 token 信息，优先用 tiktoken 精确计算，兜底字符系数
     if (usage.outputTokens === 0 && totalOutputChars > 0) {
       if (collectedOutputText) {
         // tiktoken cl100k_base 精确计算（±5%）
         usage.outputTokens = Math.max(1, countTokens(collectedOutputText))
-        proxyLogger.info('Kiro', `Estimated output tokens (tiktoken): ${totalOutputChars} chars -> ${usage.outputTokens} tokens`)
+        proxyLogger.info(
+          'Kiro',
+          `Estimated output tokens (tiktoken): ${totalOutputChars} chars -> ${usage.outputTokens} tokens`
+        )
       } else {
         // 字符系数兜底（自然语言中英混合约 0.4 token/字符）
         usage.outputTokens = Math.max(1, Math.round(totalOutputChars * 0.4))
-        proxyLogger.info('Kiro', `Estimated output tokens (fallback): ${totalOutputChars} chars -> ${usage.outputTokens} tokens`)
+        proxyLogger.info(
+          'Kiro',
+          `Estimated output tokens (fallback): ${totalOutputChars} chars -> ${usage.outputTokens} tokens`
+        )
       }
     }
-    
+
     // 流式事件聚合摘要
     if (logStreamEvents && Object.keys(streamEventCounts).length > 0) {
       const total = Object.values(streamEventCounts).reduce((a, b) => a + b, 0)
       proxyLogger.debug('Kiro', `Stream events summary (${total} total)`, streamEventCounts)
     }
-    
+
     throwIfAborted(signal)
     proxyLogger.info('Kiro', 'Stream complete, final usage', usage)
     onComplete(usage)
   } catch (error) {
-    onError(signal?.aborted ? getAbortError(signal) : error as Error)
+    onError(signal?.aborted ? getAbortError(signal) : (error as Error))
   } finally {
     signal?.removeEventListener('abort', abort)
     reader.releaseLock()
@@ -1919,14 +2354,17 @@ function getQServiceEndpoint(region?: string): string {
 }
 
 // 获取 Kiro 官方模型列表（支持分页，与官方插件一致传递 profileArn）
-export async function fetchKiroModels(account: ProxyAccount, signal?: AbortSignal): Promise<KiroModel[]> {
+export async function fetchKiroModels(
+  account: ProxyAccount,
+  signal?: AbortSignal
+): Promise<KiroModel[]> {
   const baseUrl = getQServiceEndpoint(account.region)
   const machineId = getAccountMachineId(account.id, account.machineId)
-  
+
   const headers: Record<string, string> = {
-    'Authorization': `Bearer ${account.accessToken}`,
+    Authorization: `Bearer ${account.accessToken}`,
     'Content-Type': 'application/json',
-    'Accept': 'application/json',
+    Accept: 'application/json',
     'User-Agent': getKiroUserAgent(machineId),
     'x-amz-user-agent': getKiroAmzUserAgent(machineId),
     'x-amzn-codewhisperer-optout': 'true'
@@ -1938,17 +2376,19 @@ export async function fetchKiroModels(account: ProxyAccount, signal?: AbortSigna
   try {
     do {
       const params = new URLSearchParams({ origin: 'AI_EDITOR', maxResults: '50' })
-      params.set('profileArn', resolveProfileArn(account))
+      const profileArn = await resolveAccountProfileArn(account, signal)
+      if (profileArn) params.set('profileArn', profileArn)
       if (nextToken) params.set('nextToken', nextToken)
 
       const url = `${baseUrl}/ListAvailableModels?${params.toString()}`
       throwIfAborted(signal)
       const response = await fetchWithProxy(url, { method: 'GET', headers, signal }, account)
       throwIfAborted(signal)
-      
+
       if (!response.ok) {
-        console.error('[KiroAPI] ListAvailableModels failed:', response.status)
-        break
+        const errorText = await response.text().catch(() => '')
+        console.error('[KiroAPI] ListAvailableModels failed:', response.status, errorText)
+        return allModels
       }
 
       const data = await response.json()
@@ -1960,13 +2400,13 @@ export async function fetchKiroModels(account: ProxyAccount, signal?: AbortSigna
   } catch (error) {
     if (signal?.aborted) throw getAbortError(signal)
     console.error('[KiroAPI] ListAvailableModels error:', error)
-    return allModels.length > 0 ? allModels : []
+    return allModels
   }
 }
 
 // 订阅计划信息
 export interface SubscriptionPlan {
-  name: string  // KIRO_FREE, KIRO_PRO, KIRO_PRO_PLUS, KIRO_POWER
+  name: string // KIRO_FREE, KIRO_PRO, KIRO_PRO_PLUS, KIRO_POWER
   qSubscriptionType: string
   description: {
     title: string
@@ -1990,23 +2430,29 @@ export interface SubscriptionListResponse {
 const KIRO_SUBSCRIPTION_VERSION = '0.12.155'
 
 function getSubscriptionUserAgent(machineId?: string): string {
-  const suffix = machineId ? `KiroIDE-${KIRO_SUBSCRIPTION_VERSION}-${machineId}` : `KiroIDE-${KIRO_SUBSCRIPTION_VERSION}`
+  const suffix = machineId
+    ? `KiroIDE-${KIRO_SUBSCRIPTION_VERSION}-${machineId}`
+    : `KiroIDE-${KIRO_SUBSCRIPTION_VERSION}`
   return `aws-sdk-js/1.0.0 ua/2.1 os/win32#10.0.19043 lang/js md/nodejs#22.22.0 api/codewhispererruntime#1.0.0 m/N,E ${suffix}`
 }
 
 function getSubscriptionAmzUserAgent(machineId?: string): string {
-  const suffix = machineId ? `KiroIDE-${KIRO_SUBSCRIPTION_VERSION}-${machineId}` : `KiroIDE-${KIRO_SUBSCRIPTION_VERSION}`
+  const suffix = machineId
+    ? `KiroIDE-${KIRO_SUBSCRIPTION_VERSION}-${machineId}`
+    : `KiroIDE-${KIRO_SUBSCRIPTION_VERSION}`
   return `aws-sdk-js/1.0.0 ${suffix}`
 }
 
 // 获取可用订阅列表
-export async function fetchAvailableSubscriptions(account: ProxyAccount): Promise<SubscriptionListResponse> {
+export async function fetchAvailableSubscriptions(
+  account: ProxyAccount
+): Promise<SubscriptionListResponse> {
   const baseUrl = getQServiceEndpoint(account.region)
   const url = `${baseUrl}/listAvailableSubscriptions`
   const machineId = getAccountMachineId(account.id, account.machineId)
-  
+
   const headers: Record<string, string> = {
-    'Authorization': `Bearer ${account.accessToken}`,
+    Authorization: `Bearer ${account.accessToken}`,
     'content-type': 'application/json',
     'user-agent': getSubscriptionUserAgent(machineId),
     'x-amz-user-agent': getSubscriptionAmzUserAgent(machineId),
@@ -2014,8 +2460,8 @@ export async function fetchAvailableSubscriptions(account: ProxyAccount): Promis
     'amz-sdk-request': 'attempt=1; max=1'
   }
 
-  const profileArn = resolveProfileArn(account)
-  const body = JSON.stringify({ profileArn })
+  const profileArn = await resolveAccountProfileArn(account)
+  const body = JSON.stringify(profileArn ? { profileArn } : {})
 
   console.log(`[KiroAPI] ListAvailableSubscriptions [${account.email || account.id.slice(0, 8)}]`, {
     url
@@ -2024,8 +2470,11 @@ export async function fetchAvailableSubscriptions(account: ProxyAccount): Promis
   try {
     const response = await fetchWithProxy(url, { method: 'POST', headers, body }, account)
     const responseText = await response.text()
-    console.log(`[KiroAPI] ListAvailableSubscriptions → ${response.status}`, JSON.parse(responseText))
-    
+    console.log(
+      `[KiroAPI] ListAvailableSubscriptions → ${response.status}`,
+      JSON.parse(responseText)
+    )
+
     if (!response.ok) {
       return {}
     }
@@ -2053,9 +2502,9 @@ export async function fetchSubscriptionToken(
   const baseUrl = getQServiceEndpoint(account.region)
   const url = `${baseUrl}/CreateSubscriptionToken`
   const machineId = getAccountMachineId(account.id, account.machineId)
-  
+
   const headers: Record<string, string> = {
-    'Authorization': `Bearer ${account.accessToken}`,
+    Authorization: `Bearer ${account.accessToken}`,
     'content-type': 'application/json',
     'user-agent': getSubscriptionUserAgent(machineId),
     'x-amz-user-agent': getSubscriptionAmzUserAgent(machineId),
@@ -2063,21 +2512,25 @@ export async function fetchSubscriptionToken(
     'amz-sdk-request': 'attempt=1; max=1'
   }
 
-  const profileArn = resolveProfileArn(account)
+  const profileArn = await resolveAccountProfileArn(account)
 
   // clientToken 是必需参数，需要生成 UUID
   const payload: Record<string, string> = {
     clientToken: uuidv4(),
-    profileArn,
     provider: 'STRIPE'
   }
+  if (profileArn) payload.profileArn = profileArn
   if (subscriptionType) {
     payload.subscriptionType = subscriptionType
   }
 
   try {
-    const response = await fetchWithProxy(url, { method: 'POST', headers, body: JSON.stringify(payload) }, account)
-    
+    const response = await fetchWithProxy(
+      url,
+      { method: 'POST', headers, body: JSON.stringify(payload) },
+      account
+    )
+
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}))
       console.error('[KiroAPI] CreateSubscriptionToken failed:', response.status, errorData)
@@ -2102,7 +2555,7 @@ export async function setUserPreference(
   const machineId = getAccountMachineId(account.id, account.machineId)
 
   const headers: Record<string, string> = {
-    'Authorization': `Bearer ${account.accessToken}`,
+    Authorization: `Bearer ${account.accessToken}`,
     'content-type': 'application/json',
     'user-agent': getSubscriptionUserAgent(machineId),
     'x-amz-user-agent': getSubscriptionAmzUserAgent(machineId),
@@ -2110,10 +2563,10 @@ export async function setUserPreference(
     'amz-sdk-request': 'attempt=1; max=1'
   }
 
-  const profileArn = resolveProfileArn(account)
+  const profileArn = await resolveAccountProfileArn(account)
   const body = JSON.stringify({
     overageConfiguration: { overageStatus },
-    profileArn
+    ...(profileArn ? { profileArn } : {})
   })
 
   try {

--- a/Kiro-account-manager/src/preload/index.d.ts
+++ b/Kiro-account-manager/src/preload/index.d.ts
@@ -275,6 +275,7 @@ interface KiroApi {
       region: string
       authMethod: string  // 'IdC' 或 'social'
       provider: string    // 'BuilderId', 'Github', 'Google'
+      profileArn?: string
     }
     error?: string
   }>

--- a/Kiro-account-manager/src/preload/index.ts
+++ b/Kiro-account-manager/src/preload/index.ts
@@ -222,6 +222,7 @@ const api = {
       region: string
       authMethod: string  // 'IdC' 或 'social'
       provider: string    // 'BuilderId', 'Github', 'Google'
+      profileArn?: string
     }
     error?: string
   }> => {

--- a/Kiro-account-manager/src/renderer/src/components/accounts/AddAccountDialog.tsx
+++ b/Kiro-account-manager/src/renderer/src/components/accounts/AddAccountDialog.tsx
@@ -212,7 +212,7 @@ export function AddAccountDialog({ isOpen, onClose }: AddAccountDialogProps): Re
           email,
           userId,
           nickname: email ? email.split('@')[0] : undefined,
-          idp: providerName as 'BuilderId' | 'Google' | 'Github',
+          idp: providerName as 'BuilderId' | 'Enterprise' | 'Google' | 'Github',
           credentials: {
             accessToken: result.data.accessToken,
             csrfToken: '',
@@ -223,7 +223,7 @@ export function AddAccountDialog({ isOpen, onClose }: AddAccountDialogProps): Re
             startUrl: tokenData.startUrl,
             expiresAt: result.data.expiresIn ? now + result.data.expiresIn * 1000 : now + 3600 * 1000,
             authMethod: tokenData.authMethod as 'IdC' | 'social',
-            provider: (tokenData.provider || 'BuilderId') as 'BuilderId' | 'Github' | 'Google'
+            provider: (tokenData.provider || 'BuilderId') as 'BuilderId' | 'Enterprise' | 'Github' | 'Google'
           },
           subscription: {
             type: result.data.subscriptionType as SubscriptionType,

--- a/Kiro-account-manager/src/renderer/src/store/accounts.ts
+++ b/Kiro-account-manager/src/renderer/src/store/accounts.ts
@@ -134,7 +134,8 @@ async function syncLocalSsoAccountAsync(
       email: verifyResult.data.email,
       userId: verifyResult.data.userId,
       nickname: verifyResult.data.email ? verifyResult.data.email.split('@')[0] : undefined,
-      idp: (importResult.data.provider || 'BuilderId') as 'BuilderId' | 'Google' | 'Github',
+      idp: (importResult.data.provider || 'BuilderId') as 'BuilderId' | 'Enterprise' | 'Google' | 'Github',
+      profileArn: importResult.data.profileArn,
       credentials: {
         accessToken: verifyResult.data.accessToken,
         csrfToken: '',
@@ -144,7 +145,7 @@ async function syncLocalSsoAccountAsync(
         region: importResult.data.region || 'us-east-1',
         expiresAt: verifyResult.data.expiresIn ? now + verifyResult.data.expiresIn * 1000 : now + 3600 * 1000,
         authMethod: importResult.data.authMethod as 'IdC' | 'social',
-        provider: (importResult.data.provider || 'BuilderId') as 'BuilderId' | 'Github' | 'Google'
+        provider: (importResult.data.provider || 'BuilderId') as 'BuilderId' | 'Enterprise' | 'Github' | 'Google'
       },
       subscription: {
         type: verifyResult.data.subscriptionType as SubscriptionType,


### PR DESCRIPTION
## Summary
- Route Enterprise/IAM SSO usage requests through the REST GetUsageLimits API and fall back from CBOR on invalid-parameter 400s
- Discover Enterprise Kiro profile ARNs via ListAvailableProfiles instead of falling back to the BuilderId profile ARN
- Pass Enterprise provider/profile data through model, subscription, IDE switch, CLI switch, import, and renderer account paths

## Validation
- npm run typecheck
- git diff --check
- Live Enterprise ListAvailableProfiles request returned 200 with one profile
- Live Enterprise ListAvailableModels request with discovered profileArn returned 200 with 14 models and default model auto
- Built macOS .app with npm run build:mac and copied it to /Applications/Kiro Account Manager.app

<img width="3428" height="2172" alt="Screenshot-2026-05-30-at-18-21-33-png-1624×2222--05-30-2026_06_22_PM" src="https://github.com/user-attachments/assets/66911a80-ae76-4d59-8aa1-a9ac5331e0ae" />

Also fixed issue 

Auth error 403: {"message":"Your subscription does not support this application. Please contact your administrator.","reason":null} 

<img width="1060" height="802" alt="Screenshot 2026-05-30 at 18 53 29" src="https://github.com/user-attachments/assets/1fd1977e-7ced-4de9-85bc-397eeb364a89" />


Note: npm run lint still reports pre-existing repo-wide lint debt (316 errors across the project).