### PR TITLE
v1.7.3 — Kiro IDE Token 双向同步 + BuilderId 占位符 ARN 闭环 + 主动续期 + macOS 自动…

### DIFF
--- a/Kiro-account-manager/electron-builder.yml
+++ b/Kiro-account-manager/electron-builder.yml
@@ -40,6 +40,20 @@ nsis:
   uninstallerIcon: resources/kiro-high-resolution-logo-transparent.ico
 mac:
   identity: null  # 跳过代码签名（没有 Apple 开发者证书时）
+  # 显式指定文件名格式：用 ${name}（package.json name="kiro-account-manager"）替代
+  # 默认的 ${productName}（含空格），否则 electron-builder 会把 mac zip 文件名里的空格
+  # 替换成 "."（生成 "Kiro.Account.Manager-1.7.2-mac.zip"），而 latest-mac.yml 里的
+  # url 会把空格替换成 "-"（生成 "Kiro-Account-Manager-1.7.2-mac.zip"），导致
+  # electron-updater 下载时 404。统一用 ${name} 后所有平台 / yml 命名一致。
+  artifactName: ${name}-${version}-${arch}-mac.${ext}
+  # 显式构 x64 + arm64 两个架构的 zip 和 dmg，让 latest-mac.yml 同时包含两个 zip 入口
+  # 否则 Apple Silicon 用户即便修了文件名 mismatch，updater 也只会看到 x64.zip 入口，
+  # 强行下载并以 Rosetta 模式运行
+  target:
+    - target: zip
+      arch: [x64, arm64]
+    - target: dmg
+      arch: [x64, arm64]
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.

--- a/Kiro-account-manager/package.json
+++ b/Kiro-account-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiro-account-manager",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Kiro Account Manager - Manage your Kiro accounts, usage and subscriptions",
   "main": "./out/main/index.js",
   "author": "Kiro",

--- a/Kiro-account-manager/scripts/patch-kiro-ide.cjs
+++ b/Kiro-account-manager/scripts/patch-kiro-ide.cjs
@@ -1,0 +1,422 @@
+#!/usr/bin/env node
+/* eslint-disable */
+/**
+ * patch-kiro-ide.cjs
+ *
+ * 修补 Kiro IDE 桌面端的 BuilderId 占位符 profileArn bug。
+ *
+ * 背景：Kiro IDE 在 `FixedProfileArns` 里给 BuilderId 硬编码了占位符 ARN
+ *      `arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX`，
+ *      调用 codewhisperer.us-east-1.amazonaws.com 的 REST 端点
+ *      （ListAvailableModels 等）会触发：
+ *        403 "User is not authorized to make this call."
+ *      根因：AWS Builder ID 本身不支持 profile 概念，请求不应带 profileArn。
+ *
+ * 修补点（在 extensions/kiro.kiro-agent 内的 bundled JS 中正则替换）：
+ *   1. getFixedProfileArn   —— BuilderId 短路返回 undefined
+ *   2. supportsProfiles     —— 把 BuilderId 从 IdC 列表移除
+ *   3. resolveProfileArn    —— BuilderId token 直接返回 undefined（不会再写脏数据）
+ *
+ * 同时清理已被持久化到磁盘的占位符（globalStorage/kiro.kiro-agent/profile.json）。
+ *
+ * 特性：
+ *   - 幂等：通过文件首行 MARKER 检测，已修补则跳过
+ *   - 备份：每个目标文件首次修补会写 `<file>.kpatch-backup`
+ *   - 跨平台：Windows / macOS / Linux 自动探测路径
+ *   - 可回滚：`--restore` 从备份恢复
+ *   - 可预检：`--dry-run` 输出会做什么，不真改文件
+ *
+ * 使用：
+ *   node scripts/patch-kiro-ide.cjs
+ *   node scripts/patch-kiro-ide.cjs --dry-run
+ *   node scripts/patch-kiro-ide.cjs --restore
+ *   node scripts/patch-kiro-ide.cjs --kiro-dir "D:\\Program\\Kiro"
+ *   node scripts/patch-kiro-ide.cjs --verbose
+ *
+ * Kiro 升级会覆盖 extension.js，升级后请重新运行本脚本。
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const PATCH_VERSION = 1;
+const MARKER = `/* @patched-kiro-builderid-arn-fix v${PATCH_VERSION} */`;
+const PLACEHOLDER_ARN_BUILDERID =
+  'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX';
+
+const args = parseArgs(process.argv.slice(2));
+const log = createLogger(args.verbose);
+
+function parseArgs(argv) {
+  const out = {
+    dryRun: false,
+    restore: false,
+    verbose: false,
+    kiroDir: null,
+    userDataDir: null
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case '--dry-run':
+        out.dryRun = true;
+        break;
+      case '--restore':
+        out.restore = true;
+        break;
+      case '--verbose':
+      case '-v':
+        out.verbose = true;
+        break;
+      case '--kiro-dir':
+        out.kiroDir = argv[++i];
+        break;
+      case '--userdata-dir':
+        out.userDataDir = argv[++i];
+        break;
+      case '-h':
+      case '--help':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        if (a.startsWith('--')) {
+          console.error(`Unknown option: ${a}`);
+          printHelp();
+          process.exit(64);
+        }
+    }
+  }
+  return out;
+}
+
+function printHelp() {
+  console.log(`
+patch-kiro-ide.cjs - 修补 Kiro IDE BuilderId 占位符 profileArn bug
+
+用法:
+  node patch-kiro-ide.cjs [选项]
+
+选项:
+  --dry-run             只检查不写入，输出会做什么
+  --restore             从 .kpatch-backup 还原到打补丁前
+  --verbose, -v         详细日志
+  --kiro-dir <dir>      指定 Kiro 安装根目录（默认自动探测）
+                        Win  例: D:\\Program\\Kiro
+                        mac  例: /Applications/Kiro.app/Contents/Resources/app
+                        linux例: /opt/Kiro
+  --userdata-dir <dir>  指定 Kiro userData 目录（默认自动探测）
+                        Win  例: %APPDATA%\\Kiro
+                        mac  例: ~/Library/Application Support/Kiro
+                        linux例: ~/.config/Kiro
+  -h, --help            显示帮助
+
+环境变量:
+  KIRO_DIR              同 --kiro-dir
+  KIRO_USERDATA_DIR     同 --userdata-dir
+
+退出码:
+  0  成功（含 "无需操作" / "已修补"）
+  1  运行时异常
+  2  找不到 Kiro 安装目录
+  3  找不到任何目标文件（路径或版本不匹配）
+ 64  参数错误
+`);
+}
+
+function createLogger(verbose) {
+  return {
+    info: (msg) => console.log(`[patch] ${msg}`),
+    warn: (msg) => console.warn(`[patch] WARN: ${msg}`),
+    error: (msg) => console.error(`[patch] ERROR: ${msg}`),
+    debug: (msg) => {
+      if (verbose) console.log(`[patch] DEBUG: ${msg}`);
+    }
+  };
+}
+
+function probeKiroDir(dir) {
+  if (!dir) return false;
+  const win = path.join(
+    dir,
+    'resources',
+    'app',
+    'extensions',
+    'kiro.kiro-agent',
+    'dist',
+    'extension.js'
+  );
+  if (fs.existsSync(win)) return true;
+  const mac = path.join(dir, 'extensions', 'kiro.kiro-agent', 'dist', 'extension.js');
+  if (fs.existsSync(mac)) return true;
+  return false;
+}
+
+function detectKiroDir() {
+  if (args.kiroDir) return args.kiroDir;
+  if (process.env.KIRO_DIR) return process.env.KIRO_DIR;
+
+  const platform = os.platform();
+  const candidates = [];
+  if (platform === 'win32') {
+    candidates.push(
+      'D:\\Program\\Kiro',
+      'C:\\Program Files\\Kiro',
+      'C:\\Program Files (x86)\\Kiro',
+      path.join(process.env.LOCALAPPDATA || '', 'Programs', 'Kiro')
+    );
+  } else if (platform === 'darwin') {
+    candidates.push(
+      '/Applications/Kiro.app/Contents/Resources/app',
+      path.join(os.homedir(), 'Applications/Kiro.app/Contents/Resources/app')
+    );
+  } else {
+    candidates.push('/usr/share/kiro', '/opt/Kiro', path.join(os.homedir(), '.local/share/kiro'));
+  }
+  for (const dir of candidates) {
+    if (probeKiroDir(dir)) return dir;
+  }
+  return null;
+}
+
+function detectUserDataDir() {
+  if (args.userDataDir) return args.userDataDir;
+  if (process.env.KIRO_USERDATA_DIR) return process.env.KIRO_USERDATA_DIR;
+  const platform = os.platform();
+  if (platform === 'win32') return path.join(process.env.APPDATA || '', 'Kiro');
+  if (platform === 'darwin') return path.join(os.homedir(), 'Library', 'Application Support', 'Kiro');
+  return path.join(os.homedir(), '.config', 'Kiro');
+}
+
+function getExtRoot(kiroDir) {
+  const winRoot = path.join(kiroDir, 'resources', 'app', 'extensions', 'kiro.kiro-agent');
+  if (fs.existsSync(winRoot)) return winRoot;
+  const macRoot = path.join(kiroDir, 'extensions', 'kiro.kiro-agent');
+  if (fs.existsSync(macRoot)) return macRoot;
+  return null;
+}
+
+function listTargetFiles(kiroDir) {
+  const extRoot = getExtRoot(kiroDir);
+  if (!extRoot) return [];
+
+  const targets = [];
+  const ext = path.join(extRoot, 'dist', 'extension.js');
+  if (fs.existsSync(ext)) targets.push(ext);
+
+  const sharedDist = path.join(extRoot, 'packages', 'kiro-shared', 'dist');
+  if (fs.existsSync(sharedDist)) {
+    for (const name of ['index.js', 'index.cjs']) {
+      const p = path.join(sharedDist, name);
+      if (fs.existsSync(p)) targets.push(p);
+    }
+    for (const name of fs.readdirSync(sharedDist)) {
+      if (/^external-idp-auth-provider-[A-Za-z0-9_-]+\.(js|cjs)$/.test(name)) {
+        targets.push(path.join(sharedDist, name));
+      }
+    }
+  }
+
+  // autocomplete 包只 import 这些符号、不定义它们，无需修补
+  return targets;
+}
+
+function applyReplacements(src) {
+  let touched = 0;
+
+  // 补丁 1: getFixedProfileArn 顶部插入 BuilderId 短路
+  const reFixed = /function getFixedProfileArn\(tokenProvider, currentToken\) \{\s*if \(!FixedProfileArns\.has/g;
+  src = src.replace(reFixed, () => {
+    touched++;
+    return [
+      'function getFixedProfileArn(tokenProvider, currentToken) {',
+      '  if (tokenProvider === "BuilderId") return void 0;',
+      '  if (!FixedProfileArns.has'
+    ].join('\n');
+  });
+
+  // 补丁 2: supportsProfiles 移除 BuilderId IdC 归类（extension.js 中有多份副本）
+  const reSupports = /token\.provider === "Enterprise" \|\| token\.provider === "Internal" \|\| token\.provider === "BuilderId"/g;
+  src = src.replace(reSupports, () => {
+    touched++;
+    return 'token.provider === "Enterprise" || token.provider === "Internal"';
+  });
+
+  // 补丁 3: resolveProfileArn 顶部插入 BuilderId 短路（多副本场景同样 g flag）
+  const reResolve = /async function resolveProfileArn\(options2?\) \{\s*const profileArn = await authProvider\.getProfileArn\(\);/g;
+  src = src.replace(reResolve, () => {
+    touched++;
+    return [
+      'async function resolveProfileArn(options2) {',
+      '  const __kiroPatchToken = authProvider.readToken();',
+      '  if (__kiroPatchToken && __kiroPatchToken.provider === "BuilderId") return void 0;',
+      '  const profileArn = await authProvider.getProfileArn();'
+    ].join('\n');
+  });
+
+  return { src, touched };
+}
+
+function patchFile(filePath) {
+  const original = fs.readFileSync(filePath, 'utf8');
+  if (original.startsWith(MARKER) || original.includes(MARKER)) {
+    log.debug(`already patched: ${filePath}`);
+    return { changed: false, reason: 'already-patched' };
+  }
+
+  const { src: replaced, touched } = applyReplacements(original);
+  if (touched === 0) {
+    log.warn(`no anchor matched in ${filePath} (file may be upgraded / format changed)`);
+    return { changed: false, reason: 'no-anchor' };
+  }
+
+  const patched = `${MARKER}\n${replaced}`;
+
+  if (args.dryRun) {
+    log.info(`[dry-run] would patch ${filePath} (${touched} replacement(s))`);
+    return { changed: true, touched, dryRun: true };
+  }
+
+  const bakPath = `${filePath}.kpatch-backup`;
+  if (!fs.existsSync(bakPath)) {
+    fs.writeFileSync(bakPath, original);
+    log.debug(`backup written: ${bakPath}`);
+  } else {
+    log.debug(`backup already exists, kept as-is: ${bakPath}`);
+  }
+  fs.writeFileSync(filePath, patched);
+  log.info(`patched ${filePath} (${touched} replacement(s))`);
+  return { changed: true, touched };
+}
+
+function restoreFile(filePath) {
+  const bakPath = `${filePath}.kpatch-backup`;
+  if (!fs.existsSync(bakPath)) {
+    log.debug(`no backup for ${filePath}, skip`);
+    return false;
+  }
+  if (args.dryRun) {
+    log.info(`[dry-run] would restore ${filePath} from ${bakPath}`);
+    return true;
+  }
+  fs.copyFileSync(bakPath, filePath);
+  log.info(`restored ${filePath}`);
+  return true;
+}
+
+function cleanProfileJson(userDataDir) {
+  const profilePath = path.join(
+    userDataDir,
+    'User',
+    'globalStorage',
+    'kiro.kiro-agent',
+    'profile.json'
+  );
+  if (!fs.existsSync(profilePath)) {
+    log.debug(`no profile.json at: ${profilePath}`);
+    return false;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(profilePath, 'utf8'));
+  } catch (e) {
+    log.warn(`profile.json unreadable, skip: ${e.message}`);
+    return false;
+  }
+  if (!parsed || parsed.arn !== PLACEHOLDER_ARN_BUILDERID) {
+    log.debug(`profile.json arn=${parsed && parsed.arn}, not placeholder, leave alone`);
+    return false;
+  }
+  if (args.dryRun) {
+    log.info(`[dry-run] would remove placeholder profile.json: ${profilePath}`);
+    return true;
+  }
+  const bakPath = `${profilePath}.kpatch-backup`;
+  if (!fs.existsSync(bakPath)) fs.copyFileSync(profilePath, bakPath);
+  fs.unlinkSync(profilePath);
+  log.info(`removed placeholder profile.json: ${profilePath}`);
+  return true;
+}
+
+function warnIfKiroRunning() {
+  if (os.platform() !== 'win32') return;
+  try {
+    const { execSync } = require('child_process');
+    const stdout = execSync('tasklist /FI "IMAGENAME eq Kiro.exe" /FO CSV', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8'
+    });
+    if (/^"Kiro\.exe"/m.test(stdout)) {
+      log.warn('Kiro.exe is running. It is strongly recommended to fully exit Kiro first.');
+    }
+  } catch {
+    // ignore detection errors
+  }
+}
+
+function main() {
+  log.info(
+    `patch-kiro-ide v${PATCH_VERSION} - mode=${args.dryRun ? 'dry-run' : args.restore ? 'restore' : 'apply'}`
+  );
+
+  const kiroDir = detectKiroDir();
+  if (!kiroDir) {
+    log.error('Kiro install dir not found. Pass --kiro-dir <path> or set KIRO_DIR.');
+    process.exit(2);
+  }
+  log.info(`Kiro install dir: ${kiroDir}`);
+
+  const userDataDir = detectUserDataDir();
+  log.info(`Kiro userData dir: ${userDataDir}`);
+
+  warnIfKiroRunning();
+
+  const targets = listTargetFiles(kiroDir);
+  if (targets.length === 0) {
+    log.error(
+      `No target files found under ${kiroDir}. Is this a valid Kiro install? (looked under resources/app/extensions/kiro.kiro-agent)`
+    );
+    process.exit(3);
+  }
+  log.info(`Found ${targets.length} target file(s).`);
+
+  let changes = 0;
+  if (args.restore) {
+    for (const f of targets) if (restoreFile(f)) changes++;
+    const bakProfile = path.join(
+      userDataDir,
+      'User',
+      'globalStorage',
+      'kiro.kiro-agent',
+      'profile.json.kpatch-backup'
+    );
+    if (fs.existsSync(bakProfile)) {
+      log.info(
+        `profile.json backup exists at ${bakProfile} (not restored automatically; restore manually if you really want the placeholder back)`
+      );
+    }
+  } else {
+    for (const f of targets) {
+      const r = patchFile(f);
+      if (r.changed) changes++;
+    }
+    if (cleanProfileJson(userDataDir)) changes++;
+  }
+
+  log.info(
+    `done. ${changes} file(s) ${args.restore ? 'restored' : 'changed/cleaned'}.`
+  );
+  if (!args.restore && changes > 0 && !args.dryRun) {
+    log.info('Please fully restart Kiro IDE for the patch to take effect.');
+  }
+}
+
+try {
+  main();
+} catch (e) {
+  log.error((e && (e.stack || e.message)) || String(e));
+  process.exit(1);
+}

--- a/Kiro-account-manager/src/main/index.ts
+++ b/Kiro-account-manager/src/main/index.ts
@@ -16,7 +16,15 @@ import {
   type KProxyConfig,
   type DeviceIdMapping
 } from './kproxy'
-import { fetchKiroModels, fetchSubscriptionToken, fetchAvailableSubscriptions, setUserPreference, setUseKProxyForApiInProxy, setLogStreamEvents, setPayloadSizeLimitKB, setTokenBufferReserve, setEnableTokenBufferReserve, callKiroApi } from './proxy/kiroApi'
+import { fetchKiroModels, fetchSubscriptionToken, fetchAvailableSubscriptions, setUserPreference, setUseKProxyForApiInProxy, setLogStreamEvents, setPayloadSizeLimitKB, setTokenBufferReserve, setEnableTokenBufferReserve, callKiroApi, isPlaceholderProfileArn, KIRO_BUILDER_ID_PLACEHOLDER_ARN } from './proxy/kiroApi'
+import {
+  writeKiroAuthTokenFile,
+  readKiroAuthTokenFile,
+  parseAccessTokenClaims,
+  watchKiroAuthTokenFile,
+  resolveProfileArnForWrite,
+  KIRO_AUTH_TOKEN_PATH
+} from './kiroAuthSync'
 import { openaiToKiro } from './proxy/translator'
 import { getSystemProxy, safeCreateProxyAgent } from './proxy/systemProxy'
 import { proxyLogStore, interceptConsole } from './proxy/logger'
@@ -1406,6 +1414,360 @@ async function initStore(): Promise<void> {
   } catch (error) {
     console.error('[Store] Error checking backup:', error)
   }
+
+  // 一次性迁移：清理 BuilderId 占位符 profileArn 等脏数据
+  // 详见 migrateAccountDataIfNeeded 注释
+  try {
+    migrateAccountDataIfNeeded()
+  } catch (error) {
+    console.error('[Store] Account data migration failed:', error)
+  }
+
+  // 加载主动续期开关状态（默认关闭）
+  try {
+    proactiveRenewalEnabled = !!storeInstance.get('proactiveRenewalEnabled', false)
+    console.log(`[ProactiveRenewal] Loaded from settings: ${proactiveRenewalEnabled ? 'enabled' : 'disabled'}`)
+  } catch (e) {
+    console.warn('[ProactiveRenewal] Failed to load setting:', e)
+  }
+}
+
+// ============ Kiro IDE Auth Token 反向同步 ============
+//
+// Kiro IDE 桌面端自己也有 refresh loop：每 N 秒检查 token 是否快到期，到期就用磁盘里的
+// refreshToken 调 OIDC，得到新 access + 新 refresh 后写回 ~/.aws/sso/cache/kiro-auth-token.json。
+//
+// 反代如果不感知这种"IDE 自己改了 token 文件"，下次反代再调 refresh 时还在用废的旧 refresh
+// → OIDC 拒绝 → 后续 IDE 自动刷新也连环挂掉。
+//
+// 这里启动一个 fs.watchFile 监听器：
+//   - 检测到磁盘 token 变化 + 不是反代自己刚写的（lastWrittenTokenSignature 不一致）
+//   - 把新 access/refresh/expiresAt 同步回反代 store
+//   - 通过 webContents.send 通知 renderer 重新 loadAccounts，UI 立刻刷新
+//
+// 账号匹配优先级（任一命中即视为同一账号）：
+//   1) accessToken JWT 解 sub，与反代 store 里某账号 cached accessToken claims 的 sub 一致
+//   2) lastSwitchedAccountId（反代刚 switch-account 过的那一个）
+//   3) refreshToken 旧值匹配（IDE 第一次自刷新前，磁盘 refresh 还等于 store 里的）
+let stopKiroAuthTokenWatcher: (() => void) | null = null
+
+function startKiroAuthTokenWatcher(): void {
+  if (stopKiroAuthTokenWatcher) return
+  stopKiroAuthTokenWatcher = watchKiroAuthTokenFile(async (token) => {
+    const sig = `${token.accessToken}|${token.refreshToken}`
+    if (sig === lastWrittenTokenSignature) {
+      // 反代自己刚写的，跳过避免回环
+      return
+    }
+    if (sig === lastSyncedFromIdeSignature) {
+      // 之前一次 IDE 同步已处理过这份内容，跳过
+      return
+    }
+    lastSyncedFromIdeSignature = sig
+    try {
+      await syncIdeTokenChangeToStore(token)
+    } catch (e) {
+      console.warn('[KiroAuthSync] syncIdeTokenChangeToStore failed:', e)
+    }
+  })
+  console.log('[KiroAuthSync] Watching:', KIRO_AUTH_TOKEN_PATH)
+}
+
+async function syncIdeTokenChangeToStore(token: {
+  accessToken: string
+  refreshToken: string
+  expiresAt: string
+  provider?: string
+  authMethod?: string
+  region?: string
+  profileArn?: string
+}): Promise<void> {
+  if (!store) {
+    try {
+      await initStore()
+    } catch (e) {
+      console.warn('[KiroAuthSync] initStore failed, cannot sync back:', e)
+      return
+    }
+  }
+  const accountData = store?.get('accountData') as
+    | { accounts?: Record<string, { id?: string; email?: string; credentials?: { accessToken?: string; refreshToken?: string; expiresAt?: number } }> }
+    | null
+    | undefined
+  if (!accountData?.accounts) {
+    console.log('[KiroAuthSync] No accounts in store, skip')
+    return
+  }
+
+  // 1) JWT sub 匹配（最准）
+  const newClaims = parseAccessTokenClaims(token.accessToken)
+  let matchedId: string | null = null
+  let matchedReason = ''
+  if (newClaims?.sub) {
+    for (const [id, acc] of Object.entries(accountData.accounts)) {
+      const oldClaims = acc.credentials?.accessToken
+        ? parseAccessTokenClaims(acc.credentials.accessToken)
+        : null
+      if (oldClaims?.sub && oldClaims.sub === newClaims.sub) {
+        matchedId = id
+        matchedReason = `JWT sub match (${newClaims.sub.slice(0, 12)}…)`
+        break
+      }
+    }
+  }
+
+  // 2) lastSwitchedAccountId 兜底
+  if (!matchedId && lastSwitchedAccountId && accountData.accounts[lastSwitchedAccountId]) {
+    matchedId = lastSwitchedAccountId
+    matchedReason = 'lastSwitchedAccountId fallback'
+  }
+
+  // 3) 旧 refreshToken 匹配
+  if (!matchedId) {
+    for (const [id, acc] of Object.entries(accountData.accounts)) {
+      if (acc.credentials?.accessToken === token.accessToken) {
+        // store 和 disk access 完全一致，无需同步
+        return
+      }
+      if (acc.credentials?.refreshToken && acc.credentials.refreshToken === token.refreshToken) {
+        matchedId = id
+        matchedReason = 'refreshToken exact match (no rotation yet)'
+        break
+      }
+    }
+  }
+
+  if (!matchedId) {
+    console.warn(
+      '[KiroAuthSync] IDE token file changed but no matching account in store. ' +
+        'This usually means the user signed in directly inside Kiro IDE without going through 反代切号. ' +
+        'sub=',
+      newClaims?.sub
+    )
+    return
+  }
+
+  const accountToUpdate = accountData.accounts[matchedId]
+  if (!accountToUpdate) return
+  accountToUpdate.credentials = {
+    ...accountToUpdate.credentials,
+    accessToken: token.accessToken,
+    refreshToken: token.refreshToken,
+    expiresAt: Date.parse(token.expiresAt) || Date.now() + 3600 * 1000
+  }
+
+  store!.set('accountData', accountData)
+  console.log(
+    `[KiroAuthSync] Synced IDE-refreshed token back to account ${accountToUpdate.email || matchedId} (${matchedReason})`
+  )
+
+  try {
+    mainWindow?.webContents.send('kiro-ide-token-changed', {
+      accountId: matchedId,
+      reason: matchedReason
+    })
+  } catch (e) {
+    console.warn('[KiroAuthSync] failed to notify renderer:', e)
+  }
+}
+
+// ============ 主动续期实现 ============
+//
+// 设计要点：
+//  - 仅对"当前 IDE 激活账号"调度 timer（最多 1 个 in-flight timer）
+//  - schedule 之前总是 clear，确保 timer 不会泄漏（switch 到另一账号、关闭功能、登出都会 clear）
+//  - runProactiveRenewal 内部调 refreshTokenByMethod + writeKiroAuthTokenFile（复用现有逻辑）
+//  - 续期成功后自动 schedule 下一次（基于新 token 的 expiresAt）
+//  - 续期失败：不再调度，避免无限重试；让 IDE 自己的 refresh loop 兜底（双向同步仍生效）
+//  - 通过 webContents.send('kiro-ide-token-changed') 通知 renderer 重新加载，UI 立刻刷新
+
+function clearProactiveRenewal(reason?: string): void {
+  if (proactiveRenewalTimer) {
+    clearTimeout(proactiveRenewalTimer)
+    proactiveRenewalTimer = null
+    if (reason) console.log(`[ProactiveRenewal] Timer cleared: ${reason}`)
+  }
+}
+
+/**
+ * 在 token 剩余 (PROACTIVE_RENEWAL_LEAD_MS) 时触发续期。
+ * 调用者负责传入准确的 expiresAt（来自 OIDC 真实 expiresIn），不读 store 避免不一致。
+ */
+function scheduleProactiveRenewal(accountId: string, expiresAtMs: number): void {
+  clearProactiveRenewal()
+  if (!proactiveRenewalEnabled) return
+  const msUntilRenewal = expiresAtMs - Date.now() - PROACTIVE_RENEWAL_LEAD_MS
+  // 若已经在窗口内（包括已过期），立刻续期
+  const delay = Math.max(msUntilRenewal, 0)
+  console.log(
+    `[ProactiveRenewal] Scheduled in ${Math.round(delay / 1000)}s for account ${accountId} ` +
+      `(token expiresAt ${new Date(expiresAtMs).toISOString()})`
+  )
+  proactiveRenewalTimer = setTimeout(() => {
+    proactiveRenewalTimer = null
+    void runProactiveRenewal(accountId)
+  }, delay)
+}
+
+async function runProactiveRenewal(accountId: string): Promise<void> {
+  if (!proactiveRenewalEnabled) {
+    console.log('[ProactiveRenewal] Disabled, skip run')
+    return
+  }
+  if (!store) {
+    try {
+      await initStore()
+    } catch (e) {
+      console.warn('[ProactiveRenewal] initStore failed:', e)
+      return
+    }
+  }
+  const accountData = store?.get('accountData') as
+    | { accounts?: Record<string, { id?: string; email?: string; profileArn?: string; proxyUrl?: string; credentials?: { refreshToken?: string; clientId?: string; clientSecret?: string; region?: string; authMethod?: string; startUrl?: string; provider?: string; accessToken?: string; expiresAt?: number } }> }
+    | null
+    | undefined
+  const account = accountData?.accounts?.[accountId]
+  if (!account) {
+    console.log(`[ProactiveRenewal] Account ${accountId} no longer exists, stop`)
+    return
+  }
+  const creds = account.credentials
+  if (!creds?.refreshToken) {
+    console.log(`[ProactiveRenewal] Account ${accountId} has no refreshToken, stop`)
+    return
+  }
+  console.log(
+    `[ProactiveRenewal] Renewing token for IDE active account ${account.email || accountId}...`
+  )
+  let refreshResult
+  try {
+    refreshResult = await refreshTokenByMethod(
+      creds.refreshToken,
+      creds.clientId || '',
+      creds.clientSecret || '',
+      creds.region || 'us-east-1',
+      creds.authMethod,
+      account.proxyUrl
+    )
+  } catch (e) {
+    console.warn('[ProactiveRenewal] refreshTokenByMethod threw, stop scheduling:', e)
+    return
+  }
+  if (!refreshResult.success || !refreshResult.accessToken) {
+    console.warn(
+      `[ProactiveRenewal] Renewal failed: ${refreshResult.error || 'unknown'}. ` +
+        `Stop scheduling; IDE's own refresh loop will take over as fallback.`
+    )
+    return
+  }
+  const newAccess = refreshResult.accessToken
+  const newRefresh = refreshResult.refreshToken || creds.refreshToken
+  const expiresIn = refreshResult.expiresIn ?? 3600
+  const newExpiresAt = Date.now() + expiresIn * 1000
+
+  const resolvedProfileArn = resolveProfileArnForWrite({
+    profileArn: account.profileArn,
+    authMethod: creds.authMethod,
+    provider: creds.provider
+  })
+
+  // 1. 写磁盘（同步给 IDE）
+  try {
+    await writeKiroAuthTokenFile({
+      accessToken: newAccess,
+      refreshToken: newRefresh,
+      expiresAtIso: new Date(newExpiresAt).toISOString(),
+      authMethod: (creds.authMethod === 'social' ? 'social' : 'IdC'),
+      provider: creds.provider || 'BuilderId',
+      region: creds.region,
+      startUrl: creds.startUrl,
+      clientId: creds.clientId || undefined,
+      clientSecret: creds.clientSecret || undefined,
+      profileArn: resolvedProfileArn
+    })
+    lastWrittenTokenSignature = `${newAccess}|${newRefresh}`
+    lastSwitchedAccountId = accountId
+  } catch (e) {
+    console.warn('[ProactiveRenewal] Failed to write IDE token file (will still try store sync):', e)
+  }
+
+  // 2. 写 store（同步反代/UI）
+  if (store) {
+    account.credentials = {
+      ...creds,
+      accessToken: newAccess,
+      refreshToken: newRefresh,
+      expiresAt: newExpiresAt
+    }
+    store.set('accountData', accountData)
+  }
+
+  // 3. 通知 renderer reload
+  try {
+    mainWindow?.webContents.send('kiro-ide-token-changed', {
+      accountId,
+      reason: 'proactive-renewal'
+    })
+  } catch {
+    /* renderer 可能已关闭 */
+  }
+
+  console.log(
+    `[ProactiveRenewal] Renewed OK for ${account.email || accountId}. ` +
+      `Next renewal in ${expiresIn - PROACTIVE_RENEWAL_LEAD_MS / 1000}s`
+  )
+
+  // 4. 调度下一次
+  scheduleProactiveRenewal(accountId, newExpiresAt)
+}
+
+/**
+ * 账号数据迁移：清理由旧版本反代 / Kiro IDE 桌面端写入的无效 profileArn 占位符
+ * （BuilderId 的 profile/AAAACCCCXXXX 等）。带占位符 ARN 调用 AWS REST 端点
+ * 会触发 403 "User is not authorized to make this call."。
+ *
+ * 迁移是幂等的：完成后写入 `accountDataMigration.builderIdArn = 1` 标记，
+ * 后续启动会直接跳过。检测到新脏数据（外部导入等）时会再次扫描。
+ */
+function migrateAccountDataIfNeeded(): void {
+  if (!store) return
+  const MIGRATION_KEY = 'accountDataMigration'
+  const FLAG = 'builderIdArn'
+  const migrationState = (store.get(MIGRATION_KEY, {}) as Record<string, number>) || {}
+  const accountData = store.get('accountData') as
+    | { accounts?: Record<string, { id?: string; provider?: string; profileArn?: string; email?: string }> }
+    | null
+    | undefined
+
+  if (!accountData?.accounts) {
+    if (!migrationState[FLAG]) {
+      store.set(MIGRATION_KEY, { ...migrationState, [FLAG]: 1 })
+    }
+    return
+  }
+
+  const accounts = accountData.accounts
+  let cleanedCount = 0
+  for (const id of Object.keys(accounts)) {
+    const acc = accounts[id]
+    if (!acc) continue
+    if (acc.profileArn && isPlaceholderProfileArn(acc.profileArn)) {
+      delete acc.profileArn
+      cleanedCount++
+      console.warn(
+        `[Migration] Cleared placeholder profileArn for account ${acc.email || acc.id || id} (was: ${KIRO_BUILDER_ID_PLACEHOLDER_ARN})`
+      )
+    }
+  }
+
+  if (cleanedCount > 0) {
+    store.set('accountData', accountData)
+    console.log(`[Migration] Cleaned placeholder profileArn from ${cleanedCount} account(s)`)
+  }
+
+  if (!migrationState[FLAG]) {
+    store.set(MIGRATION_KEY, { ...migrationState, [FLAG]: 1 })
+  }
 }
 
 // ============ 备份节流配置 ============
@@ -1474,6 +1836,25 @@ async function flushBackupNow(): Promise<void> {
 }
 
 let mainWindow: BrowserWindow | null = null
+
+// ============ Kiro IDE Auth 同步状态 ============
+// 账号管理器上一次写入 kiro-auth-token.json 时对应的 accountId，watcher 反向同步时优先用它
+let lastSwitchedAccountId: string | null = null
+// 账号管理器上一次写入时的 token 签名（access|refresh）。
+// watcher 触发时若签名一致，说明是账号管理器自己写的，跳过反向同步，避免回环。
+let lastWrittenTokenSignature: string | null = null
+// 上一次反向同步成功时刷写过的 store 数据签名，用于 dedupe webContents.send
+let lastSyncedFromIdeSignature: string | null = null
+
+// ============ 主动续期（Proactive Token Renewal） ============
+// 思路：在 Kiro IDE 内部 refresh loop 触发之前（token 剩 10 分钟时）抢先 refresh，
+//   让 IDE 永远拿到剩余时间充足的 token，IDE 自己永远不需要调 OIDC → 彻底消除 race。
+// 仅对"当前 IDE 激活账号"（lastSwitchedAccountId）维护一个 timer，开销小。
+// 默认关闭，需用户在 Settings 中显式打开。
+let proactiveRenewalEnabled = false
+let proactiveRenewalTimer: NodeJS.Timeout | null = null
+// 在 token 剩余多久时触发主动续期。15 分钟 > Kiro IDE 的 10 分钟阈值，确保抢先。
+const PROACTIVE_RENEWAL_LEAD_MS = 15 * 60 * 1000
 
 // ============ 托盘相关变量 ============
 let traySettings: TraySettings = { ...defaultTraySettings }
@@ -1894,6 +2275,10 @@ app.whenReady().then(async () => {
   // 初始化日志系统（尽早拦截，确保所有 console 输出都进入日志存储）
   proxyLogStore.initialize(app.getPath('userData'))
   interceptConsole()
+
+  // 启动 Kiro IDE token 文件监听（反向同步：IDE 自己 refresh 后把新 token 同步回反代 store）
+  // 见 syncIdeTokenChangeToStore 注释
+  startKiroAuthTokenWatcher()
 
   // 注册自定义协议
   registerProtocol()
@@ -2427,7 +2812,7 @@ app.whenReady().then(async () => {
   // IPC: 刷新账号 Token（支持 IdC 和社交登录）
   ipcMain.handle('refresh-account-token', async (_event, account) => {
     try {
-      const { refreshToken, clientId, clientSecret, region, authMethod } = account.credentials || {}
+      const { refreshToken, clientId, clientSecret, region, authMethod, startUrl, provider } = account.credentials || {}
 
       if (!refreshToken) {
         return { success: false, error: { message: '缺少 Refresh Token' } }
@@ -2459,18 +2844,130 @@ app.whenReady().then(async () => {
         return { success: false, error: { message: refreshResult.error || 'Token 刷新失败' } }
       }
 
+      const newAccess = refreshResult.accessToken
+      const newRefresh = refreshResult.refreshToken || refreshToken
+      const expiresIn = refreshResult.expiresIn ?? 3600
+
+      // bug B 修复：仅当该账号是 Kiro IDE 当前激活账号时，同步写入磁盘 token 文件
+      // 判定优先级（任一命中即视为"是当前激活账号"）：
+      //   1) 磁盘 token 的 refreshToken === renderer 传入的 account.credentials.refreshToken（最准）
+      //   2) account.id === lastSwitchedAccountId（反代刚切过号的兜底）
+      // 不同步的场景：用户在反代里刷新的是"非当前激活账号"，避免误覆盖 IDE 当前账号
+      let syncedToIde = false
+      let syncSkipReason: string | undefined
+      try {
+        const diskToken = await readKiroAuthTokenFile()
+        const matchByRefresh = !!diskToken && diskToken.refreshToken === refreshToken
+        const matchByLastSwitch = !!account.id && lastSwitchedAccountId === account.id
+        if (matchByRefresh || matchByLastSwitch) {
+          const resolvedProfileArn = resolveProfileArnForWrite({
+            profileArn: account.profileArn,
+            authMethod,
+            provider
+          })
+          await writeKiroAuthTokenFile({
+            accessToken: newAccess,
+            refreshToken: newRefresh,
+            expiresAtIso: new Date(Date.now() + expiresIn * 1000).toISOString(),
+            authMethod: (authMethod === 'social' ? 'social' : 'IdC'),
+            provider: provider || (diskToken?.provider as string | undefined) || 'BuilderId',
+            region: region || diskToken?.region,
+            startUrl,
+            clientId: clientId || undefined,
+            clientSecret: clientSecret || undefined,
+            profileArn: resolvedProfileArn
+          })
+          // 记录刚写入的签名，避免 watcher 触发反向同步回环
+          lastWrittenTokenSignature = `${newAccess}|${newRefresh}`
+          if (account.id) lastSwitchedAccountId = account.id
+          syncedToIde = true
+          console.log(`[Refresh] Synced refreshed token to Kiro IDE for account ${account.email || account.id}`)
+          // 重新 schedule 主动续期 timer（基于新 expiresAt，覆盖任何旧 timer）
+          if (proactiveRenewalEnabled && account.id) {
+            scheduleProactiveRenewal(account.id, Date.now() + expiresIn * 1000)
+          }
+        } else {
+          syncSkipReason = diskToken
+            ? '该账号不是 Kiro IDE 当前激活账号，跳过磁盘同步'
+            : '磁盘上未找到 kiro-auth-token.json（IDE 未登录），跳过磁盘同步'
+        }
+      } catch (e) {
+        syncSkipReason = `磁盘同步异常：${e instanceof Error ? e.message : String(e)}`
+        console.warn('[Refresh] Failed to sync token to IDE:', e)
+      }
+
       return {
         success: true,
         data: {
-          accessToken: refreshResult.accessToken,
-          refreshToken: refreshResult.refreshToken || refreshToken,
-          expiresIn: refreshResult.expiresIn ?? 3600
+          accessToken: newAccess,
+          refreshToken: newRefresh,
+          expiresIn,
+          // 让 renderer 决定是否给用户显示"已同步到 IDE"的反馈
+          syncedToIde,
+          syncSkipReason
         }
       }
     } catch (error) {
       return {
         success: false,
         error: { message: error instanceof Error ? error.message : 'Unknown error' }
+      }
+    }
+  })
+
+  // ============ 主动续期开关 IPC ============
+  // 启用后，账号管理器会在 IDE 当前激活账号的 token 剩 PROACTIVE_RENEWAL_LEAD_MS（默认 15 分钟）时
+  // 抢先 refresh + 写磁盘，IDE 永远拿到剩余 ≥ 45 分钟的 token，IDE 内部 refresh loop 不会触发，
+  // 彻底消除 IDE 与账号管理器同时 refresh 撞车的可能。
+  ipcMain.handle('set-proactive-renewal-enabled', async (_event, enabled: boolean) => {
+    try {
+      await initStore()
+      proactiveRenewalEnabled = !!enabled
+      store?.set('proactiveRenewalEnabled', proactiveRenewalEnabled)
+      console.log(`[ProactiveRenewal] ${proactiveRenewalEnabled ? 'Enabled' : 'Disabled'} by user`)
+
+      if (proactiveRenewalEnabled) {
+        // 启用时：若当前已有 IDE 激活账号，立刻 schedule
+        if (lastSwitchedAccountId) {
+          const accountData = store?.get('accountData') as
+            | { accounts?: Record<string, { credentials?: { expiresAt?: number } }> }
+            | null
+            | undefined
+          const acc = accountData?.accounts?.[lastSwitchedAccountId]
+          const exp = acc?.credentials?.expiresAt
+          if (typeof exp === 'number' && exp > Date.now()) {
+            scheduleProactiveRenewal(lastSwitchedAccountId, exp)
+          } else {
+            console.log('[ProactiveRenewal] No valid expiresAt for current IDE active account, will schedule after next switch/refresh')
+          }
+        } else {
+          console.log('[ProactiveRenewal] No IDE active account recorded yet, will schedule after next switch')
+        }
+      } else {
+        clearProactiveRenewal('disabled by user')
+      }
+      return { success: true, enabled: proactiveRenewalEnabled }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  })
+
+  ipcMain.handle('get-proactive-renewal-enabled', async () => {
+    try {
+      await initStore()
+      return {
+        success: true,
+        enabled: !!store?.get('proactiveRenewalEnabled', false),
+        leadTimeMinutes: PROACTIVE_RENEWAL_LEAD_MS / 60000
+      }
+    } catch (error) {
+      return {
+        success: false,
+        enabled: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
       }
     }
   })
@@ -3008,6 +3505,45 @@ app.whenReady().then(async () => {
               newAccessToken = refreshResult.accessToken || accessToken
               newRefreshToken = refreshResult.refreshToken || refreshToken
               newExpiresIn = refreshResult.expiresIn
+
+              // 仅当该账号是 Kiro IDE 当前激活账号时，同步新 token 到磁盘 token 文件。
+              // 否则 IDE 在 ~50min 后会用磁盘上"被自动刷新作废"的旧 refreshToken 调 OIDC → 401 → logoutAndForget。
+              // 判定优先级（任一命中）：1) 磁盘 refresh 匹配账号  2) lastSwitchedAccountId 匹配
+              if (newAccessToken && newRefreshToken && newExpiresIn) {
+                try {
+                  const diskToken = await readKiroAuthTokenFile()
+                  const matchByRefresh = !!diskToken && diskToken.refreshToken === refreshToken
+                  const matchByLastSwitch = lastSwitchedAccountId === account.id
+                  if (matchByRefresh || matchByLastSwitch) {
+                    const resolvedProfileArn = resolveProfileArnForWrite({
+                      profileArn: diskToken?.profileArn,
+                      authMethod,
+                      provider
+                    })
+                    await writeKiroAuthTokenFile({
+                      accessToken: newAccessToken,
+                      refreshToken: newRefreshToken,
+                      expiresAtIso: new Date(Date.now() + newExpiresIn * 1000).toISOString(),
+                      authMethod: (authMethod === 'social' ? 'social' : 'IdC'),
+                      provider: provider || (diskToken?.provider as string | undefined) || 'BuilderId',
+                      region: region || diskToken?.region,
+                      // background-batch-refresh 没传 startUrl，但 disk 的 clientIdHash 不再变；
+                      // helper 会用默认 startUrl 计算同一 hash，写入的 client 注册文件路径也不会变
+                      clientId: clientId || undefined,
+                      clientSecret: clientSecret || undefined,
+                      profileArn: resolvedProfileArn
+                    })
+                    lastWrittenTokenSignature = `${newAccessToken}|${newRefreshToken}`
+                    if (account.id) lastSwitchedAccountId = account.id
+                    console.log(`[BackgroundRefresh] Synced refreshed token to Kiro IDE for account ${account.id}`)
+                    if (proactiveRenewalEnabled && account.id) {
+                      scheduleProactiveRenewal(account.id, Date.now() + newExpiresIn * 1000)
+                    }
+                  }
+                } catch (e) {
+                  console.warn(`[BackgroundRefresh] sync to IDE failed for ${account.id}:`, e)
+                }
+              }
             }
 
             // 获取账号信息
@@ -3962,6 +4498,15 @@ app.whenReady().then(async () => {
   })
 
   // IPC: 切换账号 - 写入凭证到本地 SSO 缓存
+  //
+  // 关键设计：切号前必先 refresh 一次，但与旧实现不同——
+  //   1. (bug A 修复) 把 OIDC 返回的新 refreshToken 也写入磁盘
+  //      （旧实现只更新 accessToken，refreshToken 仍是已被服务端 rotate 作废的 v1，
+  //       导致 Kiro IDE ~55min 后用 v1 刷新 → 401 → logoutAndForget）
+  //   2. (bug C 修复) expiresAt 用 OIDC 返回的真实 expiresIn，不再硬编码 3600
+  //   3. (bug D 修复) refresh 失败时直接报错并拒绝写入文件，避免埋雷
+  //   4. (bug F 支持) 通过 refreshedCredentials 把新 refresh 回传 renderer，让反代 store 同步
+  //   5. 记录 lastSwitchedAccountId，供 fs.watch 反向同步时用作账号匹配兜底
   ipcMain.handle('switch-account', async (_event, credentials: {
     accessToken: string
     refreshToken: string
@@ -3972,102 +4517,92 @@ app.whenReady().then(async () => {
     authMethod?: 'IdC' | 'social'
     provider?: 'BuilderId' | 'Github' | 'Google' | 'Enterprise'
     profileArn?: string
+    accountId?: string
   }) => {
-    const os = await import('os')
-    const path = await import('path')
-    const crypto = await import('crypto')
-    const { mkdir, writeFile } = await import('fs/promises')
-    
     try {
-      const { 
-        refreshToken, 
-        clientId, 
-        clientSecret, 
+      const {
+        refreshToken,
+        clientId,
+        clientSecret,
         region = 'us-east-1',
         startUrl,
         authMethod = 'IdC',
         provider = 'BuilderId',
-        profileArn
+        profileArn,
+        accountId
       } = credentials
-      let { accessToken } = credentials
+      let finalAccessToken = credentials.accessToken
+      let finalRefreshToken = refreshToken
+      let finalExpiresIn = 3600
 
-      // 切号前先刷新 token，确保写入的 accessToken 是最新的
-      // Kiro IDE 会直接使用 accessToken（不过期就不刷新），旧 token 会导致 Invalid token
+      // 切号前先 refresh，确保磁盘里写的是最新 access + 最新 refresh（rotating）
       if (refreshToken) {
         console.log(`[Switch Account] Refreshing token before switch (authMethod: ${authMethod})...`)
         const refreshResult = await refreshTokenByMethod(refreshToken, clientId, clientSecret, region, authMethod)
         if (refreshResult.success && refreshResult.accessToken) {
-          accessToken = refreshResult.accessToken
-          console.log('[Switch Account] Token refreshed successfully')
+          finalAccessToken = refreshResult.accessToken
+          // bug A 修复：OIDC 返回新 refreshToken 时必须替换；否则下次 IDE/反代 refresh 会撞已作废的 v1
+          finalRefreshToken = refreshResult.refreshToken || refreshToken
+          finalExpiresIn = refreshResult.expiresIn ?? 3600
+          console.log('[Switch Account] Token refreshed successfully (rotated refreshToken updated)')
         } else {
-          console.warn(`[Switch Account] Token refresh failed: ${refreshResult.error}, using existing token`)
+          // bug D 修复：refresh 失败不写文件 + 直接报错，避免给 IDE 留下"半坏"token
+          const errMsg = refreshResult.error || 'Unknown refresh error'
+          console.warn(`[Switch Account] Token refresh failed, aborting switch: ${errMsg}`)
+          return {
+            success: false,
+            error: `刷新 Token 失败，未写入 Kiro IDE 磁盘文件，避免下次自动刷新失败导致 IDE 强制登出。原因：${errMsg}`
+          }
         }
       }
-      
-      // 计算 clientIdHash (与 Kiro 客户端一致)
-      // Enterprise 账户使用自己的 startUrl，BuilderId 使用默认的
-      const effectiveStartUrl = startUrl || 'https://view.awsapps.com/start'
-      const clientIdHash = crypto.createHash('sha1')
-        .update(JSON.stringify({ startUrl: effectiveStartUrl }))
-        .digest('hex')
-      
-      // 确保目录存在
-      const ssoCache = path.join(os.homedir(), '.aws', 'sso', 'cache')
-      await mkdir(ssoCache, { recursive: true })
-      
-      // 根据 provider 推导 profileArn（官方固定规则）
-      const SOCIAL_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK'
-      const BUILDER_ID_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX'
-      const resolvedProfileArn = profileArn
-        || (authMethod === 'social' || provider === 'Google' || provider === 'Github' ? SOCIAL_PROFILE_ARN : BUILDER_ID_PROFILE_ARN)
 
-      // 写入 token 文件（格式与官方 Kiro IDE 完全一致）
-      const tokenPath = path.join(ssoCache, 'kiro-auth-token.json')
-      const tokenData: Record<string, unknown> = authMethod === 'social'
-        ? {
-            // Social 登录格式：accessToken, refreshToken, profileArn, expiresAt, authMethod, provider
-            accessToken,
-            refreshToken,
-            profileArn: resolvedProfileArn,
-            expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
-            authMethod,
-            provider
-          }
-        : {
-            // IdC 登录格式：accessToken, refreshToken, expiresAt, clientIdHash, authMethod, provider, region
-            accessToken,
-            refreshToken,
-            expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
-            clientIdHash,
-            authMethod,
-            provider,
-            region,
-            profileArn: resolvedProfileArn
-          }
-      await writeFile(tokenPath, JSON.stringify(tokenData, null, 2))
-      console.log('[Switch Account] Token saved to:', tokenPath)
-      
-      // 只有 IdC 登录需要写入客户端注册文件
-      if (authMethod !== 'social' && clientId && clientSecret) {
-        const clientRegPath = path.join(ssoCache, `${clientIdHash}.json`)
-        const expiresAt = new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString().replace('Z', '')
-        const clientData = {
-          clientId,
-          clientSecret,
-          expiresAt,
-          scopes: [
-            'codewhisperer:completions',
-            'codewhisperer:analysis',
-            'codewhisperer:conversations',
-            'codewhisperer:transformations',
-            'codewhisperer:taskassist'
-          ]
-        }
-        await writeFile(clientRegPath, JSON.stringify(clientData, null, 2))
-        console.log('[Switch Account] Client registration saved to:', clientRegPath)
+      // profileArn 决策统一由 helper：BuilderId 永远返回 undefined（不写占位符）
+      const resolvedProfileArn = resolveProfileArnForWrite({
+        profileArn,
+        authMethod,
+        provider
+      })
+
+      // bug C 修复：用真实 expiresIn 算 expiresAt
+      const expiresAtIso = new Date(Date.now() + finalExpiresIn * 1000).toISOString()
+
+      const { tokenPath, clientRegPath } = await writeKiroAuthTokenFile({
+        accessToken: finalAccessToken,
+        refreshToken: finalRefreshToken,
+        expiresAtIso,
+        authMethod,
+        provider,
+        region,
+        startUrl,
+        clientId,
+        clientSecret,
+        profileArn: resolvedProfileArn
+      })
+      console.log('[Switch Account] Token written to:', tokenPath)
+      if (clientRegPath) {
+        console.log('[Switch Account] Client registration written to:', clientRegPath)
       }
-      
-      return { success: true }
+
+      // 记录 lastSwitchedAccountId（供 watcher 反向同步时识别 IDE 当前账号）
+      if (accountId) {
+        lastSwitchedAccountId = accountId
+        // 同步记录 access/refresh 的"信任源头"，避免 watcher 把刚写的同一份数据再回写一次
+        lastWrittenTokenSignature = `${finalAccessToken}|${finalRefreshToken}`
+        // 如启用了主动续期，立刻 schedule 下一次（基于刚写入的 expiresAt）
+        if (proactiveRenewalEnabled) {
+          scheduleProactiveRenewal(accountId, Date.now() + finalExpiresIn * 1000)
+        }
+      }
+
+      return {
+        success: true,
+        // bug F 支持：回传 refresh 后的最新 credentials 让 renderer 更新 store
+        refreshedCredentials: {
+          accessToken: finalAccessToken,
+          refreshToken: finalRefreshToken,
+          expiresIn: finalExpiresIn
+        }
+      }
     } catch (error) {
       console.error('[Switch Account] Error:', error)
       return { success: false, error: error instanceof Error ? error.message : '切换失败' }
@@ -4129,10 +4664,13 @@ app.whenReady().then(async () => {
       const preferredTokenKey = isSocial ? 'kirocli:social:token' : 'kirocli:odic:token'
       const preferredRegKey = 'kirocli:odic:device-registration'
 
-      // 根据 provider 推导 profileArn
-      const SOCIAL_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK'
-      const BUILDER_ID_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX'
-      const resolvedProfileArn = profileArn || (isSocial ? SOCIAL_PROFILE_ARN : BUILDER_ID_PROFILE_ARN)
+      // profileArn 决策统一由 helper：BuilderId 不带 profileArn
+      // kiro-cli 同样不应该在 SQLite 里塞占位符 ARN（实测会触发 REST 端点 403）
+      const resolvedProfileArn = resolveProfileArnForWrite({
+        profileArn,
+        authMethod: isSocial ? 'social' : 'IdC',
+        provider
+      })
 
       // 构建 token JSON（snake_case 字段名，与 kiro-cli Rust 结构一致）
       const expiresAt = new Date(Date.now() + 3600 * 1000).toISOString()
@@ -4140,8 +4678,11 @@ app.whenReady().then(async () => {
         access_token: accessToken,
         refresh_token: refreshToken,
         expires_at: expiresAt,
-        region,
-        profile_arn: resolvedProfileArn
+        region
+      }
+      // profileArn 仅在解析出有效值时附加，BuilderId 等不带（避免 kiro-cli 拿占位符 ARN 调 REST 触发 403）
+      if (resolvedProfileArn) {
+        tokenData.profile_arn = resolvedProfileArn
       }
       if (scopes) tokenData.scopes = scopes
 
@@ -4210,7 +4751,12 @@ app.whenReady().then(async () => {
     const os = await import('os')
     const path = await import('path')
     const { readdir, unlink } = await import('fs/promises')
-    
+
+    // 立刻清掉主动续期 timer 和"激活账号"记忆，避免 watcher / timer 误同步
+    clearProactiveRenewal('logout-account')
+    lastSwitchedAccountId = null
+    lastWrittenTokenSignature = null
+
     try {
       const ssoCache = path.join(os.homedir(), '.aws', 'sso', 'cache')
       console.log('[Logout] Clearing SSO cache:', ssoCache)

--- a/Kiro-account-manager/src/main/kiroAuthSync.ts
+++ b/Kiro-account-manager/src/main/kiroAuthSync.ts
@@ -1,0 +1,280 @@
+// Kiro IDE Auth Token 同步层
+//
+// Kiro IDE 桌面端把 token 持久化在 ~/.aws/sso/cache/kiro-auth-token.json，
+// 并对该文件做 fs.watchFile 监听 + 内部 refresh loop。
+//
+// 反代和 IDE 必须以这个文件作为 single source of truth，否则会出现：
+//   反代 store 里 refreshToken_v2，磁盘里 refreshToken_v1（已被服务端轮换作废）
+//   → IDE 一小时后用 v1 调 OIDC → 401 → logoutAndForget()
+//
+// 本模块提供：
+//   writeKiroAuthTokenFile  — 以 Kiro IDE 兼容格式写入 token 文件（+ IdC 客户端注册）
+//   readKiroAuthTokenFile   — 读取当前磁盘 token
+//   parseAccessTokenClaims  — 解 accessToken 的 JWT 拿到 sub/email，用于反向匹配账号
+//   watchKiroAuthTokenFile  — 监听文件变化（IDE 自己 refresh 时用于反向同步到反代 store）
+
+import * as fs from 'fs/promises'
+import * as fsSync from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import * as crypto from 'crypto'
+
+export const KIRO_SSO_CACHE_DIR = path.join(os.homedir(), '.aws', 'sso', 'cache')
+export const KIRO_AUTH_TOKEN_PATH = path.join(KIRO_SSO_CACHE_DIR, 'kiro-auth-token.json')
+
+const KIRO_DEFAULT_START_URL = 'https://view.awsapps.com/start'
+const KIRO_OIDC_SCOPES = [
+  'codewhisperer:completions',
+  'codewhisperer:analysis',
+  'codewhisperer:conversations',
+  'codewhisperer:transformations',
+  'codewhisperer:taskassist'
+]
+
+// =============== profileArn 决策中心 ===============
+//
+// 占位符 ARN：Kiro IDE 源码 FixedProfileArns 里给 BuilderId 硬编码的 fake 值。
+// 实测对 codewhisperer.us-east-1.amazonaws.com REST 端点会 403 "User is not authorized"。
+// AWS Builder ID 不支持 profile 概念，请求应当完全不带 profileArn。
+export const KIRO_BUILDER_ID_PLACEHOLDER_ARN = 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX'
+// Social 登录（Github/Google）共用的 Kiro 后端固定 profileArn
+export const KIRO_SOCIAL_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK'
+
+const PLACEHOLDER_PROFILE_ARNS = new Set<string>([KIRO_BUILDER_ID_PLACEHOLDER_ARN])
+
+/** 检查给定 ARN 是不是已知占位符（旧版反代 / Kiro IDE 自身可能写入的脏数据） */
+export function isPlaceholderProfileArn(arn: string | undefined | null): boolean {
+  if (!arn) return false
+  return PLACEHOLDER_PROFILE_ARNS.has(arn)
+}
+
+/**
+ * 写入 token 文件前对 profileArn 的"应该写啥"做统一决策。
+ *
+ * 规则（优先级）：
+ *   1. 调用方显式给出 profileArn 且非已知占位符 → 直接用
+ *   2. social/Github/Google → 用固定 Kiro Social profileArn
+ *   3. 其它（BuilderId、Enterprise、Internal、未知）→ undefined，不带 profileArn
+ *
+ * BuilderId 等账号绝不能带占位符 ARN，否则 IDE 后续 REST 调用会 403。
+ */
+export function resolveProfileArnForWrite(input: {
+  profileArn?: string
+  authMethod?: string
+  provider?: string
+}): string | undefined {
+  if (input.profileArn && !isPlaceholderProfileArn(input.profileArn)) {
+    return input.profileArn
+  }
+  if (input.authMethod === 'social' || input.provider === 'Github' || input.provider === 'Google') {
+    return KIRO_SOCIAL_PROFILE_ARN
+  }
+  return undefined
+}
+
+export interface KiroAuthTokenFile {
+  accessToken: string
+  refreshToken: string
+  expiresAt: string
+  authMethod?: 'IdC' | 'social' | string
+  provider?: string
+  region?: string
+  clientIdHash?: string
+  profileArn?: string
+}
+
+export interface WriteKiroAuthTokenInput {
+  accessToken: string
+  refreshToken: string
+  /** ISO 字符串。建议用 OIDC 返回的真实 expiresIn 算 */
+  expiresAtIso: string
+  authMethod: 'IdC' | 'social'
+  provider: string
+  region?: string
+  startUrl?: string
+  /** IdC 必填：会一起写客户端注册文件 */
+  clientId?: string
+  clientSecret?: string
+  profileArn?: string
+}
+
+export interface WriteKiroAuthTokenResult {
+  tokenPath: string
+  clientRegPath?: string
+}
+
+function computeClientIdHash(startUrl?: string): string {
+  return crypto
+    .createHash('sha1')
+    .update(JSON.stringify({ startUrl: startUrl || KIRO_DEFAULT_START_URL }))
+    .digest('hex')
+}
+
+/**
+ * 以与 Kiro IDE 完全兼容的格式写入 ~/.aws/sso/cache/kiro-auth-token.json
+ * - mode 0o600：与 IDE 保持一致（writeTokenToDisk 用 0o600 即 384）
+ * - social 与 IdC 字段顺序对齐 Kiro IDE 序列化结果，便于人工 diff
+ * - IdC 同时写客户端注册文件 {clientIdHash}.json
+ */
+export async function writeKiroAuthTokenFile(
+  input: WriteKiroAuthTokenInput
+): Promise<WriteKiroAuthTokenResult> {
+  // 最后一道防线：占位符 ARN 进来就 strip，确保 BuilderId 永远不被写入占位符
+  if (isPlaceholderProfileArn(input.profileArn)) {
+    input = { ...input, profileArn: undefined }
+  }
+
+  await fs.mkdir(KIRO_SSO_CACHE_DIR, { recursive: true })
+
+  const clientIdHash = computeClientIdHash(input.startUrl)
+
+  const tokenData: Record<string, unknown> =
+    input.authMethod === 'social'
+      ? {
+          accessToken: input.accessToken,
+          refreshToken: input.refreshToken,
+          profileArn: input.profileArn,
+          expiresAt: input.expiresAtIso,
+          authMethod: input.authMethod,
+          provider: input.provider
+        }
+      : {
+          accessToken: input.accessToken,
+          refreshToken: input.refreshToken,
+          expiresAt: input.expiresAtIso,
+          clientIdHash,
+          authMethod: input.authMethod,
+          provider: input.provider,
+          region: input.region || 'us-east-1',
+          profileArn: input.profileArn
+        }
+
+  await fs.writeFile(KIRO_AUTH_TOKEN_PATH, JSON.stringify(tokenData, null, 2), {
+    mode: 0o600
+  })
+  // Windows 上 chmod 对 0o600 是 no-op 但不抛错；Linux/macOS 上保证权限正确
+  try {
+    await fs.chmod(KIRO_AUTH_TOKEN_PATH, 0o600)
+  } catch {
+    /* ignore */
+  }
+
+  let clientRegPath: string | undefined
+  if (input.authMethod !== 'social' && input.clientId && input.clientSecret) {
+    clientRegPath = path.join(KIRO_SSO_CACHE_DIR, `${clientIdHash}.json`)
+    // IDE 客户端注册有效期 90 天（Kiro IDE 原版做法），格式为去掉 Z 的 ISO 字符串
+    const clientExpiresAt = new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString().replace('Z', '')
+    const clientData = {
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+      expiresAt: clientExpiresAt,
+      scopes: KIRO_OIDC_SCOPES
+    }
+    await fs.writeFile(clientRegPath, JSON.stringify(clientData, null, 2), { mode: 0o600 })
+    try {
+      await fs.chmod(clientRegPath, 0o600)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return { tokenPath: KIRO_AUTH_TOKEN_PATH, clientRegPath }
+}
+
+export async function readKiroAuthTokenFile(): Promise<KiroAuthTokenFile | null> {
+  try {
+    const content = await fs.readFile(KIRO_AUTH_TOKEN_PATH, 'utf-8')
+    const parsed = JSON.parse(content) as KiroAuthTokenFile
+    if (!parsed.accessToken || !parsed.refreshToken) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * 解 accessToken 的 JWT 第二段（payload）拿 sub / email / aud / preferred_username。
+ * - 如果不是 JWT 格式返回 null
+ * - 不验证签名（只用于反向匹配账号）
+ */
+export interface AccessTokenClaims {
+  sub?: string
+  email?: string
+  aud?: string
+  preferredUsername?: string
+}
+
+export function parseAccessTokenClaims(accessToken: string): AccessTokenClaims | null {
+  if (!accessToken) return null
+  const parts = accessToken.split('.')
+  if (parts.length < 2) return null
+  try {
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    while (b64.length % 4) b64 += '='
+    const json = Buffer.from(b64, 'base64').toString('utf-8')
+    const claims = JSON.parse(json) as Record<string, unknown>
+    const audRaw = claims.aud
+    const aud = typeof audRaw === 'string' ? audRaw : Array.isArray(audRaw) && typeof audRaw[0] === 'string' ? (audRaw[0] as string) : undefined
+    return {
+      sub: typeof claims.sub === 'string' ? (claims.sub as string) : undefined,
+      email: typeof claims.email === 'string' ? (claims.email as string) : undefined,
+      aud,
+      preferredUsername:
+        typeof claims['preferred_username'] === 'string'
+          ? (claims['preferred_username'] as string)
+          : undefined
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * 监听 Kiro IDE 的 token 文件变化。
+ * - 使用 fs.watchFile（polling）以保证跨平台一致性
+ * - 内部做内容防抖（同一对 accessToken+refreshToken 不重复触发）
+ * - 返回 dispose 函数
+ */
+export type WatchCallback = (token: KiroAuthTokenFile) => void | Promise<void>
+
+export function watchKiroAuthTokenFile(onChange: WatchCallback, intervalMs = 2000): () => void {
+  let debounceTimer: NodeJS.Timeout | null = null
+  let lastSeenSig = ''
+  let disposed = false
+
+  const tick = async (): Promise<void> => {
+    if (disposed) return
+    try {
+      const token = await readKiroAuthTokenFile()
+      if (!token) return
+      const sig = `${token.accessToken}|${token.refreshToken}`
+      if (sig === lastSeenSig) return
+      lastSeenSig = sig
+      await onChange(token)
+    } catch (e) {
+      // 静默：watcher 不应该 throw 影响主进程
+      console.warn('[kiroAuthSync] watcher tick failed:', e)
+    }
+  }
+
+  const listener = (): void => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      void tick()
+    }, 600)
+  }
+
+  // 先做一次基线读，避免启动后第一次"虚假变更"
+  void readKiroAuthTokenFile().then((t) => {
+    if (t) lastSeenSig = `${t.accessToken}|${t.refreshToken}`
+  })
+
+  fsSync.watchFile(KIRO_AUTH_TOKEN_PATH, { interval: intervalMs }, listener)
+
+  return () => {
+    disposed = true
+    if (debounceTimer) clearTimeout(debounceTimer)
+    fsSync.unwatchFile(KIRO_AUTH_TOKEN_PATH, listener)
+  }
+}

--- a/Kiro-account-manager/src/main/proxy/kiroApi.ts
+++ b/Kiro-account-manager/src/main/proxy/kiroApi.ts
@@ -186,14 +186,33 @@ const KIRO_CLI_AMZ_USER_AGENT = `aws-sdk-rust/1.3.9 ua/2.1 api/ssooidc/1.88.0 os
 const AGENT_MODE_SPEC = 'spec' // IDE 模式
 const AGENT_MODE_VIBE = 'vibe' // CLI 模式
 
-const KIRO_BUILDER_ID_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX'
-const KIRO_SOCIAL_PROFILE_ARN = 'arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK'
+// profileArn 决策中心已迁移到 ../kiroAuthSync，反代和账号管理器主进程共用同一份定义，
+// 防止多处常量漂移。注意 KIRO_BUILDER_ID_PLACEHOLDER_ARN 仍以本模块为出口 re-export，
+// 这样 main/index.ts 等老 import 路径不需要改。
+import {
+  KIRO_BUILDER_ID_PLACEHOLDER_ARN as _KIRO_BUILDER_ID_PLACEHOLDER_ARN,
+  KIRO_SOCIAL_PROFILE_ARN,
+  isPlaceholderProfileArn as _isPlaceholderProfileArn,
+  resolveProfileArnForWrite
+} from '../kiroAuthSync'
 
-function resolveProfileArn(account: ProxyAccount): string {
-  if (account.profileArn) return account.profileArn
-  if (account.provider === 'Github' || account.provider === 'Google') return KIRO_SOCIAL_PROFILE_ARN
-  return KIRO_BUILDER_ID_PROFILE_ARN
+export const KIRO_BUILDER_ID_PLACEHOLDER_ARN = _KIRO_BUILDER_ID_PLACEHOLDER_ARN
+export const isPlaceholderProfileArn = _isPlaceholderProfileArn
+
+/**
+ * 反代调 Kiro API 时使用的 profileArn 决策。
+ * BuilderId 等"不支持 profile"的账号返回 undefined，避免 REST 端点 403。
+ */
+function resolveProfileArn(account: ProxyAccount): string | undefined {
+  return resolveProfileArnForWrite({
+    profileArn: account.profileArn,
+    authMethod: account.authMethod,
+    provider: account.provider
+  })
 }
+
+// 兼容 SDK 部分调用仍想知道社交 ARN 的场景（极少；保留 export 不破坏外部 import）
+export { KIRO_SOCIAL_PROFILE_ARN }
 
 // Agentic 模式系统提示 - 防止大文件写入超时
 const AGENTIC_SYSTEM_PROMPT = `# CRITICAL: CHUNKED WRITE PROTOCOL (MANDATORY)
@@ -327,7 +346,7 @@ function isCodeWhispererModelId(modelId: string): boolean {
 }
 
 function getModelCacheKey(account: ProxyAccount): string {
-  return `${account.id}:${account.region || 'us-east-1'}:${resolveProfileArn(account)}`
+  return `${account.id}:${account.region || 'us-east-1'}:${resolveProfileArn(account) ?? 'no-arn'}`
 }
 
 async function getCachedCodeWhispererModels(account: ProxyAccount, signal?: AbortSignal): Promise<KiroModel[]> {
@@ -1202,7 +1221,12 @@ export async function callKiroApiStream(
     try {
       throwIfAborted(signal)
       const requestPayload = clonePayload(payload)
-      requestPayload.profileArn = resolveProfileArn(account)
+      const resolvedArn = resolveProfileArn(account)
+      if (resolvedArn) {
+        requestPayload.profileArn = resolvedArn
+      } else {
+        delete requestPayload.profileArn
+      }
       const requestedModelId = getPayloadModelId(requestPayload)
       if (endpoint.name === 'CodeWhisperer') {
         applyPayloadModelId(requestPayload, await resolveCodeWhispererModelId(account, requestedModelId, signal))
@@ -1958,7 +1982,9 @@ export async function fetchKiroModels(account: ProxyAccount, signal?: AbortSigna
   try {
     do {
       const params = new URLSearchParams({ origin: 'AI_EDITOR', maxResults: '50' })
-      params.set('profileArn', resolveProfileArn(account))
+      // BuilderId 等账号不携带 profileArn，避免 AWS 后端对占位符 ARN 返回 403
+      const arnForModels = resolveProfileArn(account)
+      if (arnForModels) params.set('profileArn', arnForModels)
       if (nextToken) params.set('nextToken', nextToken)
 
       const url = `${baseUrl}/ListAvailableModels?${params.toString()}`
@@ -2035,10 +2061,12 @@ export async function fetchAvailableSubscriptions(account: ProxyAccount): Promis
   }
 
   const profileArn = resolveProfileArn(account)
-  const body = JSON.stringify({ profileArn })
+  // BuilderId 不带 profileArn；带空/占位符会被 AWS 后端拒绝
+  const body = JSON.stringify(profileArn ? { profileArn } : {})
 
   console.log(`[KiroAPI] ListAvailableSubscriptions [${account.email || account.id.slice(0, 8)}]`, {
-    url
+    url,
+    hasProfileArn: profileArn !== undefined
   })
 
   try {
@@ -2085,11 +2113,13 @@ export async function fetchSubscriptionToken(
 
   const profileArn = resolveProfileArn(account)
 
-  // clientToken 是必需参数，需要生成 UUID
+  // clientToken 是必需参数；profileArn 仅在解析出有效值时附带
   const payload: Record<string, string> = {
     clientToken: uuidv4(),
-    profileArn,
     provider: 'STRIPE'
+  }
+  if (profileArn) {
+    payload.profileArn = profileArn
   }
   if (subscriptionType) {
     payload.subscriptionType = subscriptionType
@@ -2131,10 +2161,13 @@ export async function setUserPreference(
   }
 
   const profileArn = resolveProfileArn(account)
-  const body = JSON.stringify({
-    overageConfiguration: { overageStatus },
-    profileArn
-  })
+  const bodyPayload: Record<string, unknown> = {
+    overageConfiguration: { overageStatus }
+  }
+  if (profileArn) {
+    bodyPayload.profileArn = profileArn
+  }
+  const body = JSON.stringify(bodyPayload)
 
   try {
     const response = await fetchWithProxy(url, { method: 'POST', headers, body }, account)

--- a/Kiro-account-manager/src/preload/index.d.ts
+++ b/Kiro-account-manager/src/preload/index.d.ts
@@ -53,8 +53,21 @@ interface RefreshResult {
     accessToken: string
     refreshToken?: string
     expiresIn: number
+    /**
+     * 反代在 main 进程中是否已经把新 token 同步写入 ~/.aws/sso/cache/kiro-auth-token.json。
+     * 仅当该账号被识别为 Kiro IDE 当前激活账号时才会同步，否则为 false。
+     */
+    syncedToIde?: boolean
+    /** 未同步到 IDE 时的原因描述（用于 UI 提示） */
+    syncSkipReason?: string
   }
   error?: { message: string }
+}
+
+/** Kiro IDE 自己 refresh 完写回 token 文件、被反代检测到后通知 renderer 的 payload */
+interface KiroIdeTokenChangedPayload {
+  accountId: string
+  reason: string
 }
 
 interface BonusData {
@@ -180,7 +193,44 @@ interface KiroApi {
     authMethod?: 'IdC' | 'social'
     provider?: 'BuilderId' | 'Enterprise' | 'Github' | 'Google' | 'IAM_SSO'
     profileArn?: string
-  }) => Promise<{ success: boolean; error?: string }>
+    /** 反代 store 里的 account.id，用于 main 进程记忆 lastSwitchedAccountId 供 watcher 反向同步 */
+    accountId?: string
+  }) => Promise<{
+    success: boolean
+    error?: string
+    /** 切号前 main 进程会做一次 refresh；这是 OIDC 返回的最新凭证，renderer 应据此更新 store */
+    refreshedCredentials?: {
+      accessToken: string
+      refreshToken: string
+      expiresIn: number
+    }
+  }>
+
+  /**
+   * 订阅 Kiro IDE 自己 refresh token 后反代检测到的事件，回调里通常应该重新 loadAccounts
+   * 让 UI 显示最新 expiresAt。返回 unsubscribe 函数。
+   */
+  onKiroIdeTokenChanged: (callback: (data: KiroIdeTokenChangedPayload) => void) => () => void
+
+  /**
+   * 开启/关闭"主动续期"功能。
+   * 开启后账号管理器会在 IDE 当前激活账号 token 剩 ~15 分钟时抢先 refresh + 写磁盘，
+   * 让 IDE 永远拿到剩余时间充足的 token，IDE 内部的 refresh loop 不会被触发，
+   * 彻底消除 IDE 与账号管理器同时 refresh 撞车的可能。
+   */
+  setProactiveRenewalEnabled: (enabled: boolean) => Promise<{
+    success: boolean
+    enabled?: boolean
+    error?: string
+  }>
+
+  /** 读取主动续期开关当前状态 + 提前续期的分钟数 */
+  getProactiveRenewalEnabled: () => Promise<{
+    success: boolean
+    enabled: boolean
+    leadTimeMinutes?: number
+    error?: string
+  }>
 
   // 切换账号到 Kiro CLI - 写入凭证到 SQLite 数据库
   switchAccountCli: (credentials: {

--- a/Kiro-account-manager/src/preload/index.ts
+++ b/Kiro-account-manager/src/preload/index.ts
@@ -137,8 +137,32 @@ const api = {
     authMethod?: 'IdC' | 'social'
     provider?: 'BuilderId' | 'Github' | 'Google' | 'Enterprise'
     profileArn?: string
-  }): Promise<{ success: boolean; error?: string }> => {
+    accountId?: string
+  }): Promise<{
+    success: boolean
+    error?: string
+    refreshedCredentials?: { accessToken: string; refreshToken: string; expiresIn: number }
+  }> => {
     return ipcRenderer.invoke('switch-account', credentials)
+  },
+
+  // 订阅 Kiro IDE 自己 refresh token 后反代检测到的事件
+  onKiroIdeTokenChanged: (callback: (data: { accountId: string; reason: string }) => void): (() => void) => {
+    const handler = (_event: unknown, data: { accountId: string; reason: string }): void => {
+      callback(data)
+    }
+    ipcRenderer.on('kiro-ide-token-changed', handler)
+    return (): void => {
+      ipcRenderer.removeListener('kiro-ide-token-changed', handler)
+    }
+  },
+
+  // 主动续期开关：开启后账号管理器会在 IDE refresh 阈值前抢先 refresh，IDE 永不自刷
+  setProactiveRenewalEnabled: (enabled: boolean): Promise<{ success: boolean; enabled?: boolean; error?: string }> => {
+    return ipcRenderer.invoke('set-proactive-renewal-enabled', enabled)
+  },
+  getProactiveRenewalEnabled: (): Promise<{ success: boolean; enabled: boolean; leadTimeMinutes?: number; error?: string }> => {
+    return ipcRenderer.invoke('get-proactive-renewal-enabled')
   },
 
   // 切换账号到 Kiro CLI - 写入凭证到 SQLite 数据库

--- a/Kiro-account-manager/src/renderer/src/App.tsx
+++ b/Kiro-account-manager/src/renderer/src/App.tsx
@@ -90,6 +90,8 @@ function App(): React.JSX.Element {
     loadFromStorage().then(() => {
       startAutoTokenRefresh()
     })
+    // 同步主动续期开关（持久化在 main 进程的 electron-store）
+    useAccountsStore.getState().loadProactiveRenewalEnabled()
     // 加载 Webhook 配置
     useWebhookStore.getState().loadFromStorage()
 
@@ -97,6 +99,18 @@ function App(): React.JSX.Element {
       stopAutoTokenRefresh()
     }
   }, [loadFromStorage, startAutoTokenRefresh, stopAutoTokenRefresh])
+
+  // 订阅 Kiro IDE 自己 refresh token 后反代检测到的事件
+  // 触发时间点：Kiro IDE 在后台 refresh loop 把磁盘 token 写新了，反代 watcher 反向同步到 store
+  // 这里收到事件后从磁盘重新加载账号数据，让 UI 立刻显示最新 expiresAt / accessToken
+  useEffect(() => {
+    if (typeof window.api.onKiroIdeTokenChanged !== 'function') return
+    const unsubscribe = window.api.onKiroIdeTokenChanged((data) => {
+      console.log(`[App] Kiro IDE refreshed token for account ${data.accountId} (${data.reason}), reloading accounts...`)
+      loadFromStorage().catch((e) => console.warn('[App] reload after IDE token change failed:', e))
+    })
+    return unsubscribe
+  }, [loadFromStorage])
 
   // 反代关键事件 → 触发 webhook（v1.8 新增）
   // 由 main/proxyServer 内置的 webhookTrigger 通过 IPC 推送过来，统一在 renderer 调 useWebhookStore

--- a/Kiro-account-manager/src/renderer/src/components/accounts/AccountCard.tsx
+++ b/Kiro-account-manager/src/renderer/src/components/accounts/AccountCard.tsx
@@ -240,7 +240,8 @@ export const AccountCard = memo(function AccountCard({
       startUrl: credentials.startUrl,
       authMethod: credentials.authMethod,
       provider: credentials.provider,
-      profileArn: account.profileArn
+      profileArn: account.profileArn,
+      accountId: account.id
     }
 
     let success = true
@@ -249,7 +250,30 @@ export const AccountCard = memo(function AccountCard({
     // 根据 switchTarget 设置决定切换目标
     if (switchTarget === 'ide' || switchTarget === 'both') {
       const result = await window.api.switchAccount(idePayload)
-      if (!result.success) { success = false; errorMsg = result.error || '' }
+      if (!result.success) {
+        success = false
+        errorMsg = result.error || ''
+      } else if (result.refreshedCredentials) {
+        // 同步 main 进程 refresh 后的最新 credentials 到 store，避免反代 store 留下已作废的 refreshToken
+        const rc = result.refreshedCredentials
+        useAccountsStore.setState((state) => {
+          const accounts = new Map(state.accounts)
+          const acc = accounts.get(account.id)
+          if (acc) {
+            accounts.set(account.id, {
+              ...acc,
+              credentials: {
+                ...acc.credentials,
+                accessToken: rc.accessToken,
+                refreshToken: rc.refreshToken,
+                expiresAt: Date.now() + rc.expiresIn * 1000
+              }
+            })
+          }
+          return { accounts }
+        })
+        useAccountsStore.getState().saveToStorage()
+      }
     }
     if (switchTarget === 'cli' || switchTarget === 'both') {
       const result = await window.api.switchAccountCli(cliPayload)

--- a/Kiro-account-manager/src/renderer/src/components/accounts/AccountListRow.tsx
+++ b/Kiro-account-manager/src/renderer/src/components/accounts/AccountListRow.tsx
@@ -165,7 +165,8 @@ function AccountListRowComponent({
       startUrl: credentials.startUrl,
       authMethod: credentials.authMethod,
       provider: credentials.provider,
-      profileArn: account.profileArn
+      profileArn: account.profileArn,
+      accountId: account.id
     }
 
     let success = true
@@ -173,7 +174,30 @@ function AccountListRowComponent({
     const target = switchTarget || 'ide'
     if (target === 'ide' || target === 'both') {
       const result = await window.api.switchAccount(idePayload)
-      if (!result.success) { success = false; errorMsg = result.error || '' }
+      if (!result.success) {
+        success = false
+        errorMsg = result.error || ''
+      } else if (result.refreshedCredentials) {
+        // 同步 main 进程 refresh 后的最新 credentials 到 store，避免反代 store 留下已作废的 refreshToken
+        const rc = result.refreshedCredentials
+        useAccountsStore.setState((state) => {
+          const accounts = new Map(state.accounts)
+          const acc = accounts.get(account.id)
+          if (acc) {
+            accounts.set(account.id, {
+              ...acc,
+              credentials: {
+                ...acc.credentials,
+                accessToken: rc.accessToken,
+                refreshToken: rc.refreshToken,
+                expiresAt: Date.now() + rc.expiresIn * 1000
+              }
+            })
+          }
+          return { accounts }
+        })
+        useAccountsStore.getState().saveToStorage()
+      }
     }
     if (target === 'cli' || target === 'both') {
       const result = await window.api.switchAccountCli(cliPayload)

--- a/Kiro-account-manager/src/renderer/src/components/accounts/AccountToolbar.tsx
+++ b/Kiro-account-manager/src/renderer/src/components/accounts/AccountToolbar.tsx
@@ -11,7 +11,6 @@ import {
   Plus,
   Upload,
   Download,
-  RefreshCw,
   Trash2,
   Tag,
   FolderPlus,
@@ -30,7 +29,9 @@ import {
   Users,
   Inbox,
   ArrowRightLeft,
-  Zap
+  Zap,
+  Activity,
+  KeyRound
 } from 'lucide-react'
 
 export type AccountViewMode = 'grid' | 'list'
@@ -819,7 +820,8 @@ export function AccountToolbar({
               : (isEn ? 'Check accounts info (select first)' : '检查账户信息（请先选中账号）')
             }
           >
-            {isChecking ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            {/* 与 batchRefresh 区分图标：Activity 代表"查看状态/活动" */}
+            {isChecking ? <Loader2 className="h-4 w-4 animate-spin" /> : <Activity className="h-4 w-4" />}
           </Button>
           <Button
             variant="ghost"
@@ -858,7 +860,8 @@ export function AccountToolbar({
               : (isEn ? 'Refresh Token (select first)' : '刷新 Token（请先选中账号）')
             }
           >
-            {isRefreshing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            {/* 与 batchCheck 区分图标：KeyRound 代表"刷新令牌"，与 AccountCard 单账号视图一致 */}
+            {isRefreshing ? <Loader2 className="h-4 w-4 animate-spin" /> : <KeyRound className="h-4 w-4" />}
           </Button>
 
           <div className="w-px h-6 bg-border mx-1" />

--- a/Kiro-account-manager/src/renderer/src/components/pages/RegisterPage.tsx
+++ b/Kiro-account-manager/src/renderer/src/components/pages/RegisterPage.tsx
@@ -2672,6 +2672,27 @@ export function RegisterPage(): React.JSX.Element {
         </CardContent>
       </Card>
 
+      {/* 日志（紧跟"开始注册"卡片，方便观察进度，不再放到页面最底部） */}
+      {logs.length > 0 && (
+        <Card className="overflow-hidden">
+          <CardHeader className="py-3 border-b">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-sm">{t('register.log')}</CardTitle>
+              <Button variant="ghost" size="sm" onClick={() => { _logs = []; setLogs([]) }}>
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div ref={logContainerRef} className="h-48 overflow-y-auto p-3 font-mono text-xs space-y-0.5 bg-muted/20">
+              {logs.map((line, i) => (
+                <div key={i} className="text-muted-foreground leading-relaxed">{line}</div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* 批量注册 (非手动模式) */}
       {mode !== 'manual' && (
         <Card className="hover-lift">
@@ -3280,26 +3301,6 @@ export function RegisterPage(): React.JSX.Element {
         </Card>
       )}
 
-      {/* 日志 */}
-      {logs.length > 0 && (
-        <Card className="overflow-hidden">
-          <CardHeader className="py-3 border-b">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-sm">{t('register.log')}</CardTitle>
-              <Button variant="ghost" size="sm" onClick={() => { _logs = []; setLogs([]) }}>
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="p-0">
-            <div ref={logContainerRef} className="h-48 overflow-y-auto p-3 font-mono text-xs space-y-0.5 bg-muted/20">
-              {logs.map((line, i) => (
-                <div key={i} className="text-muted-foreground leading-relaxed">{line}</div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
     </div>
   )
 }

--- a/Kiro-account-manager/src/renderer/src/components/pages/SettingsPage.tsx
+++ b/Kiro-account-manager/src/renderer/src/components/pages/SettingsPage.tsx
@@ -166,6 +166,9 @@ export function SettingsPage() {
     autoRefreshInterval,
     autoRefreshConcurrency,
     autoRefreshSyncInfo,
+    proactiveRenewalEnabled,
+    proactiveRenewalLeadMinutes,
+    setProactiveRenewalEnabled,
     setAutoRefresh,
     setAutoRefreshConcurrency,
     setAutoRefreshSyncInfo,
@@ -622,6 +625,78 @@ export function SettingsPage() {
               {autoRefreshEnabled ? (isEn ? 'On' : '已开启') : (isEn ? 'Off' : '已关闭')}
             </Button>
           </div>
+
+          <div className="text-xs text-muted-foreground bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900 rounded-lg p-3 space-y-1">
+            <p className="font-medium text-amber-700 dark:text-amber-300">
+              {isEn ? 'About Kiro IDE auto refresh' : '关于 Kiro IDE 自动刷新'}
+            </p>
+            <p>
+              {isEn
+                ? '• Kiro IDE has its own internal refresh loop (independent of this app). Disabling Auto Refresh here only stops this app from refreshing — it does NOT stop Kiro IDE.'
+                : '• Kiro IDE 自带独立的刷新循环，关闭本工具的"自动刷新"不会停止 IDE 自己的刷新。'}
+            </p>
+            <p>
+              {isEn
+                ? '• When switching accounts or refreshing tokens here, the new token is synced to ~/.aws/sso/cache/kiro-auth-token.json only for the IDE current active account; other accounts only update the local store.'
+                : '• 切号 / 刷新 Token 时，仅当该账号是 Kiro IDE 当前激活账号才会同步到磁盘文件；非激活账号仅更新本工具内部 store。'}
+            </p>
+            <p>
+              {isEn
+                ? '• If IDE refreshes the token itself, this app detects the file change and syncs the new token back to its store (bidirectional sync).'
+                : '• 当 Kiro IDE 自己 refresh 后，本工具会监听磁盘文件变化并反向同步到 store（双向同步）。'}
+            </p>
+          </div>
+
+          {/* 主动续期开关（默认关闭） */}
+          <div className="flex items-center justify-between pt-3 border-t">
+            <div>
+              <p className="font-medium">
+                {isEn ? 'Proactive Token Renewal for IDE' : 'IDE 主动续期'}
+                <span className="ml-2 text-xs text-muted-foreground">
+                  ({isEn ? 'Advanced' : '进阶'})
+                </span>
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {isEn
+                  ? `Renew IDE's active token ~${proactiveRenewalLeadMinutes} min before expiry, so Kiro IDE never refreshes by itself (eliminates all race conditions).`
+                  : `在 IDE 激活账号的 token 剩 ~${proactiveRenewalLeadMinutes} 分钟时抢先 refresh，让 Kiro IDE 永远不自己 refresh（彻底消除竞争条件）。`}
+              </p>
+            </div>
+            <Button
+              variant={proactiveRenewalEnabled ? 'default' : 'outline'}
+              size="sm"
+              onClick={async () => {
+                const result = await setProactiveRenewalEnabled(!proactiveRenewalEnabled)
+                if (!result.success && result.error) {
+                  alert(
+                    (isEn ? 'Failed to toggle proactive renewal: ' : '切换主动续期失败：') +
+                      result.error
+                  )
+                }
+              }}
+            >
+              {proactiveRenewalEnabled ? (isEn ? 'On' : '已开启') : (isEn ? 'Off' : '已关闭')}
+            </Button>
+          </div>
+          {proactiveRenewalEnabled && (
+            <div className="text-xs text-muted-foreground bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-900 rounded-lg p-3 space-y-1">
+              <p>
+                {isEn
+                  ? `• On: a single in-process timer renews token ${proactiveRenewalLeadMinutes} min before expiry; Kiro IDE keeps seeing fresh tokens (≥${60 - proactiveRenewalLeadMinutes} min remaining) and never invokes OIDC by itself.`
+                  : `• 启用后：账号管理器主进程会在 token 剩 ${proactiveRenewalLeadMinutes} 分钟时自动续期，Kiro IDE 始终看到剩余 ≥ ${60 - proactiveRenewalLeadMinutes} 分钟的 token，永远不会自己调 OIDC。`}
+              </p>
+              <p>
+                {isEn
+                  ? '• Only the IDE current active account is renewed. Switching accounts re-schedules the timer for the new active account.'
+                  : '• 仅对 IDE 当前激活账号续期。切号时 timer 会自动重新调度到新账号。'}
+              </p>
+              <p>
+                {isEn
+                  ? '• If a renewal fails (e.g. server outage), the timer stops; IDE\'s own refresh loop takes over as fallback.'
+                  : '• 续期失败时 timer 停止，由 IDE 自己的 refresh loop 接管（双向同步仍生效）。'}
+              </p>
+            </div>
+          )}
 
           {autoRefreshEnabled && (
             <>

--- a/Kiro-account-manager/src/renderer/src/store/accounts.ts
+++ b/Kiro-account-manager/src/renderer/src/store/accounts.ts
@@ -268,6 +268,10 @@ interface AccountsState {
   autoRefreshSyncInfo: boolean // 刷新时是否同步检测账户信息（用量、订阅、封禁状态）
   statusCheckInterval: number // 分钟
 
+  // 主动续期开关（持久化在 main 进程的 electron-store；这里只是镜像，不写 saveToStorage）
+  proactiveRenewalEnabled: boolean
+  proactiveRenewalLeadMinutes: number
+
   // 隐私模式
   privacyMode: boolean
 
@@ -394,6 +398,10 @@ interface AccountsActions {
   setAutoRefresh: (enabled: boolean, interval?: number) => void
   setAutoRefreshConcurrency: (concurrency: number) => void
   setAutoRefreshSyncInfo: (enabled: boolean) => void
+  /** 调 main 进程的 IPC，同步开启/关闭主动续期；成功后更新本地镜像 */
+  setProactiveRenewalEnabled: (enabled: boolean) => Promise<{ success: boolean; error?: string }>
+  /** 从 main 进程读取主动续期开关当前状态 */
+  loadProactiveRenewalEnabled: () => Promise<void>
   setStatusCheckInterval: (interval: number) => void
 
   // 隐私模式
@@ -547,6 +555,8 @@ export const useAccountsStore = create<AccountsStore>()((set, get) => ({
   autoRefreshConcurrency: 100,
   autoRefreshSyncInfo: true,
   statusCheckInterval: 60,
+  proactiveRenewalEnabled: false,
+  proactiveRenewalLeadMinutes: 15,
   privacyMode: false,
   usagePrecision: false,
   proxyEnabled: false,
@@ -1311,6 +1321,18 @@ export const useAccountsStore = create<AccountsStore>()((set, get) => ({
       const result = await window.api.refreshAccountToken(account)
 
       if (result.success && result.data) {
+        // 当 refresh 后 main 进程检测到该账号是 IDE 当前激活账号，会自动同步到磁盘 token 文件；
+        // 否则只更新反代 store，IDE 仍用旧 token —— 提醒用户避免误以为"刷新对 IDE 也生效了"
+        if (result.data.syncedToIde) {
+          console.log(`[refreshAccountToken] Token refreshed AND synced to Kiro IDE (account=${account.email})`)
+        } else {
+          console.warn(
+            `[refreshAccountToken] Token refreshed but NOT synced to Kiro IDE (account=${account.email}). ` +
+              `Reason: ${result.data.syncSkipReason || 'unknown'}. ` +
+              `Kiro IDE will still use its previously cached token until its own refresh loop kicks in.`
+          )
+        }
+
         set((state) => {
           const accounts = new Map(state.accounts)
           const acc = accounts.get(id)
@@ -1868,6 +1890,32 @@ export const useAccountsStore = create<AccountsStore>()((set, get) => ({
     get().saveToStorage()
   },
 
+  setProactiveRenewalEnabled: async (enabled) => {
+    if (typeof window.api?.setProactiveRenewalEnabled !== 'function') {
+      return { success: false, error: 'API not available' }
+    }
+    const result = await window.api.setProactiveRenewalEnabled(enabled)
+    if (result.success) {
+      set({ proactiveRenewalEnabled: !!result.enabled })
+    }
+    return { success: result.success, error: result.error }
+  },
+
+  loadProactiveRenewalEnabled: async () => {
+    if (typeof window.api?.getProactiveRenewalEnabled !== 'function') return
+    try {
+      const result = await window.api.getProactiveRenewalEnabled()
+      if (result.success) {
+        set({
+          proactiveRenewalEnabled: !!result.enabled,
+          proactiveRenewalLeadMinutes: result.leadTimeMinutes ?? 15
+        })
+      }
+    } catch (e) {
+      console.warn('[Store] loadProactiveRenewalEnabled failed:', e)
+    }
+  },
+
   setStatusCheckInterval: (interval) => {
     set({ statusCheckInterval: interval })
     get().saveToStorage()
@@ -2091,7 +2139,7 @@ export const useAccountsStore = create<AccountsStore>()((set, get) => ({
         const { switchTarget: target } = get()
         const creds = availableAccount.credentials
         if (target === 'ide' || target === 'both') {
-          await window.api.switchAccount({
+          const switchResult = await window.api.switchAccount({
             accessToken: creds.accessToken || '',
             refreshToken: creds.refreshToken || '',
             clientId: creds.clientId || '',
@@ -2100,8 +2148,31 @@ export const useAccountsStore = create<AccountsStore>()((set, get) => ({
             startUrl: creds.startUrl,
             authMethod: creds.authMethod,
             provider: creds.provider,
-            profileArn: (availableAccount as { profileArn?: string }).profileArn
+            profileArn: (availableAccount as { profileArn?: string }).profileArn,
+            accountId: availableAccount.id
           })
+          // 把 main 进程 refresh 后的最新 credentials 同步回 store，
+          // 否则 store 里的 refreshToken 仍是 v1（已被服务端 rotate 作废），下次任何 refresh 都会失败
+          if (switchResult?.success && switchResult.refreshedCredentials) {
+            const rc = switchResult.refreshedCredentials
+            set((state) => {
+              const accounts = new Map(state.accounts)
+              const acc = accounts.get(availableAccount.id)
+              if (acc) {
+                accounts.set(availableAccount.id, {
+                  ...acc,
+                  credentials: {
+                    ...acc.credentials,
+                    accessToken: rc.accessToken,
+                    refreshToken: rc.refreshToken,
+                    expiresAt: Date.now() + rc.expiresIn * 1000
+                  }
+                })
+              }
+              return { accounts }
+            })
+            get().saveToStorage()
+          }
         }
         if (target === 'cli' || target === 'both') {
           window.api.switchAccountCli?.({

--- a/README.md
+++ b/README.md
@@ -272,6 +272,71 @@ The project is configured with GitHub Actions workflow for auto building all pla
 ## 📋 Changelog
 
 
+### v1.7.3 (2026-6-4) — Kiro IDE Token Bidirectional Sync + BuilderId Placeholder ARN Full Closure + Proactive Renewal + macOS Auto-Update Fix
+
+> This release focuses on the core failure "after switching accounts / refreshing tokens in this app, Kiro IDE desktop gets force-logged-out ~1 hour later", closes the chain of bugs where BuilderId accounts still got written placeholder profileArn in multiple paths, adds an optional IDE Token proactive-renewal capability (off by default), fixes macOS auto-update 404, and ships a Kiro IDE binary patcher script plus several UI tweaks.
+
+#### 🔥 Core Fix: Kiro IDE Token Bidirectional Sync (resolves "force-logout ~1h after switching")
+
+- **Fix**: 🔥 **`switch-account` wrote the already-rotated/invalidated old refreshToken to disk** — the old code only updated the local variable `accessToken` after calling OIDC for `access_v2 + refresh_v2`, but the `refreshToken` written into `~/.aws/sso/cache/kiro-auth-token.json` was still `v1` (immediately invalidated by BuilderId's rotating refresh-token mechanism). Kiro IDE's refresh loop later used `v1` against OIDC → 401 → `logoutAndForget()` force-logout
+- **Fix**: 🔥 **`refresh-account-token` ("Refresh Token" button) never wrote to disk at all** — the old code only updated the in-app store and notified the renderer; the disk token file was untouched, so Kiro IDE never saw the new token. The UI showed "refreshed" but IDE actually kept using the old one and hit the same 401 → logout ~1h later
+- **Fix**: 🔥 **`background-batch-refresh` (the IPC used by "Auto Refresh") also never wrote to disk** — the Auto Refresh feature (default every 5 minutes) refreshed all accounts but never synced to the IDE disk file. This was the biggest hidden hole after the switch/refresh-button fixes. Now every refreshed account, if recognized as the IDE current active account, is auto-synced
+- **Fix**: `switch-account` hardcoded `expiresAt = Date.now() + 3600*1000`; now uses the real `expiresIn` returned by OIDC
+- **Fix**: `switch-account` previously still wrote the old token on OIDC refresh failure (planting a landmine); now it errors out without writing and surfaces a clear message
+
+#### 🔁 New Module: `src/main/kiroAuthSync.ts` and Bidirectional Sync
+
+- **New**: `writeKiroAuthTokenFile` / `readKiroAuthTokenFile` shared helpers — uniformly read/write `~/.aws/sso/cache/kiro-auth-token.json` in a fully Kiro-IDE-compatible format (`mode 0o600` etc.); social / IdC field ordering matches the IDE source serializer
+- **New**: `parseAccessTokenClaims` — decodes the JWT body of an access token for `sub / email / aud`, used during reverse sync to identify "which account did the IDE just self-refresh"
+- **New**: `watchKiroAuthTokenFile` — uses `fs.watchFile` with content-level debouncing; hooked up on app start
+- **New**: **Reverse sync pipeline** — when Kiro IDE self-refreshes and writes new token to disk → the watcher fires → 3-tier account matching (JWT sub / `lastSwitchedAccountId` / refreshToken equality) finds the account in store → updates credentials → `webContents.send('kiro-ide-token-changed')` triggers renderer to `loadFromStorage`, UI immediately shows latest `expiresAt`
+- **New**: Anti-loop — `lastWrittenTokenSignature` (the token written by this app itself) is recognized by the watcher and skipped, preventing ping-pong between IDE and the app
+- **New**: `switchAccount` IPC returns `refreshedCredentials` (the real post-refresh access/refresh/expiresIn); the renderer immediately syncs to store, eliminating the cascading bug "store still holds v1 → next refresh hits invalidated refresh"
+
+#### 🛡️ BuilderId Placeholder profileArn Full Closure
+
+- **Fix**: 🔥 **Kiro IDE desktop's `FixedProfileArns` hardcodes the placeholder ARN `profile/AAAACCCCXXXX` for BuilderId** — calling `codewhisperer.us-east-1.amazonaws.com/ListAvailableModels` with this ARN deterministically triggers 403 "User is not authorized to make this call." The reverse-proxy side `kiroApi.ts`'s `resolveProfileArn` now returns no profileArn for BuilderId and unknown providers; all call sites (`fetchKiroModels` / `callKiroApiStream` / 3 subscription endpoints) guard with null-checks
+- **Fix**: 🔥 **4 disk-write paths (`switch-account` / `switch-account-cli` / `refresh-account-token` sync branch / `runProactiveRenewal`) still inlined the placeholder ARN** — BuilderId accounts were force-stamped this placeholder into `~/.aws/sso/cache/kiro-auth-token.json` or `~/.local/share/kiro-cli/data.sqlite3`, planting the same landmine for Kiro IDE / kiro-cli REST calls. All paths now use the unified `resolveProfileArnForWrite` helper, which always returns `undefined` for BuilderId
+- **New**: `kiroAuthSync.ts` centrally hosts `KIRO_BUILDER_ID_PLACEHOLDER_ARN` / `KIRO_SOCIAL_PROFILE_ARN`; reverse-proxy `kiroApi.ts` becomes a re-exporter, eliminating drift risk across 5 duplicated constants
+- **New**: Last-line-of-defense inside `writeKiroAuthTokenFile` — if a placeholder ARN is detected in input, it is automatically stripped to `undefined`, catching anything that bypassed the helper
+- **New**: On boot, `migrateAccountDataIfNeeded` performs a one-time scan of account data in electron-store, clearing placeholder ARNs written by older versions / Kiro IDE itself, then writes back idempotently
+
+#### 🆕 New: IDE Token Proactive Renewal (off by default)
+
+- **New**: A **"Proactive Token Renewal for IDE"** toggle has been added beneath the Auto Refresh block in Settings — when enabled, the app's main process refreshes + writes-to-disk ~15 minutes before the IDE active account's token expires, so Kiro IDE always sees ≥ 45 minutes remaining and its internal `attemptRefreshIfCloseToExpiry` never fires, completely eliminating any race against OIDC rotation
+- **New**: Maintains a single in-process timer (lowest possible cost) tied to the IDE current active account; `switch-account` / `refresh-account-token` / `logout-account` all schedule or clear the timer correctly with zero leaks
+- **New**: On renewal failure, the timer halts and the IDE's own refresh loop takes over — naturally complementary to the bidirectional-sync mechanism
+- **New**: Persisted in electron-store (`proactiveRenewalEnabled` key) and auto-restored after restarting the app
+
+#### 🧰 Kiro IDE Binary Patcher `scripts/patch-kiro-ide.cjs`
+
+- **New**: Cross-platform script — performs 3 precise regex replacements against Kiro IDE desktop's `extension.js` and the bundled JS under `packages/kiro-shared`:
+  - `getFixedProfileArn`: short-circuit `void 0` for BuilderId
+  - `supportsProfiles`: remove BuilderId from the IdC list
+  - `resolveProfileArn`: return `void 0` directly for BuilderId tokens
+- **New**: Also cleans the placeholder ARN persisted in `%APPDATA%/Kiro/User/globalStorage/kiro.kiro-agent/profile.json`
+- **New**: Idempotent (first-line MARKER) + backup (`.kpatch-backup`) + flags: `--dry-run` / `--restore` / `--verbose` / `--kiro-dir`; re-run the same command after Kiro IDE upgrades to re-patch
+- **Usage**: `node scripts/patch-kiro-ide.cjs --dry-run` for preview; `node scripts/patch-kiro-ide.cjs` to apply. Fully quit Kiro before running
+
+#### 🔧 Build / Release
+
+- **Fix**: 🔥 **macOS auto-update 404** — by default, `electron-builder` replaces spaces in `productName` with `.` for the mac zip filename (yielding `Kiro.Account.Manager-1.7.2-mac.zip`), but the `url` field in `latest-mac.yml` replaces spaces with `-` (pointing at `Kiro-Account-Manager-1.7.2-mac.zip`). The mismatch caused updater 404. `electron-builder.yml` now sets `mac.artifactName: ${name}-${version}-${arch}-mac.${ext}` and explicit `target: zip/dmg × [x64, arm64]`, unifying naming to `kiro-account-manager-…` across platforms and making `latest-mac.yml` include both x64 and arm64 entries so Apple Silicon users get a native arm64 build
+- **Note**: Existing v1.7.2 macOS users cannot auto-upgrade to v1.7.3 due to the above bug; please download the matching dmg/zip from [Releases](https://github.com/chaogei/Kiro-account-manager/releases/latest) manually one time
+
+#### 🎨 UI / Detail Tweaks
+
+- **Optimize**: Registration page — the "Log" card has been moved from the bottom of the page to right after the "Start Registration" button card, so live progress is visible at a glance
+- **Optimize**: Account toolbar — "Batch Check Account Info" and "Batch Refresh Token" both previously used the `RefreshCw` icon and were visually indistinguishable; now respectively switched to `Activity` (check/activity semantic) and `KeyRound` (refresh-token semantic, consistent with the card view) with i18n tooltips
+- **New**: Bidirectional-sync explainer block added beneath Auto Refresh in Settings — clarifying "Kiro IDE has its own internal refresh loop", "switch/refresh syncs to disk only for the IDE current active account", and "the app reverse-syncs back to store when IDE self-refreshes"
+- **New**: `onKiroIdeTokenChanged` IPC event — renderer subscribes and triggers `loadFromStorage` on receipt; the UI refreshes `expiresAt` instantly after IDE self-refresh
+
+#### 🔍 Validation
+
+- Full-project `npm run typecheck:node && npm run typecheck:web` both pass with zero errors
+- ReadLints reports zero warnings across all modified files
+- The Kiro IDE patcher script's `--dry-run` precisely targets all 5 candidate files on Windows D:\Program\Kiro (3 + 1 + 1 + 1 + 1 replacements)
+
+
 ### v1.7.2 (2026-6-2) — Batch Subscription Link Enhancements + Card-Key Parsing Fix + Group Assignment on Add/Import
 
 > This release focuses on bulk import & quick-pick batched opening in the Subscription "Get Links" view, a boundary-character fix in card-key/credential parsing (resolving import-verification 401s), and assigning accounts to a chosen group when adding / batch-adding / importing.

--- a/README_CN.md
+++ b/README_CN.md
@@ -272,6 +272,71 @@ npx electron-builder --linux --arm64
 ## 📋 更新日志
 
 
+### v1.7.3 (2026-6-4) — Kiro IDE Token 双向同步 + BuilderId 占位符 ARN 闭环修复 + 主动续期 + macOS 自动更新修复
+
+> 本版本聚焦解决"通过本工具切号 / 刷新 Token 后，Kiro IDE 桌面端约 1 小时后被强制登出"的核心故障，闭环修掉 BuilderId 账号在多处仍被写入占位符 profileArn 的连环 bug，新增可选的 IDE Token 主动续期能力（默认关闭），修复 macOS 自动更新 404，附带 Kiro IDE 二进制补丁器脚本与若干 UI 细节调整。
+
+#### 🔥 核心修复：Kiro IDE Token 双向同步（修复"切号 ~1h 后 IDE 强制登出"）
+
+- **修复**: 🔥 **`switch-account` 写入磁盘的 refreshToken 是已被服务端 rotate 作废的旧值** — 旧实现在调 OIDC 拿到 `access_v2 + refresh_v2` 后只更新本地变量 `accessToken`，写入 `~/.aws/sso/cache/kiro-auth-token.json` 时 `refreshToken` 仍是 `v1`（已被 BuilderId 的 rotating refresh token 机制立即作废）。Kiro IDE 在 ~50 分钟后 refresh loop 用 `v1` 调 OIDC → 401 → `logoutAndForget()` 强制登出
+- **修复**: 🔥 **`refresh-account-token`（"刷新 Token"按钮）从来不写磁盘文件** — 旧实现只更新工具内 store 并通知 renderer，磁盘 token 文件没动；Kiro IDE 永远看不到新 token，UI 显示"已刷新"但 IDE 实际仍用旧的，约 1 小时后撞同样的 401 → 登出
+- **修复**: 🔥 **`background-batch-refresh`（自动刷新走的批量 IPC）也不写磁盘** — "自动刷新"功能（默认 5 分钟一次）刷新所有账号但永远不同步到 IDE 磁盘，是修复"切号"和"刷新 Token"按钮后的最大隐藏漏洞。现在每个账号刷新成功后，若识别为 IDE 当前激活账号则自动同步
+- **修复**: `switch-account` 的 `expiresAt` 硬编码 `Date.now() + 3600*1000`，现改用 OIDC 返回的真实 `expiresIn`
+- **修复**: `switch-account` 在 OIDC 刷新失败时仍用旧 token 写文件埋雷，现直接报错不写文件，并提示用户
+
+#### 🔁 新模块：`src/main/kiroAuthSync.ts` 与双向同步
+
+- **新增**: `writeKiroAuthTokenFile` / `readKiroAuthTokenFile` 共用 helper，统一以 Kiro IDE 完全兼容的格式（`mode 0o600` 等）读写 `~/.aws/sso/cache/kiro-auth-token.json`；社交 / IdC 字段顺序对齐 IDE 源码序列化结果
+- **新增**: `parseAccessTokenClaims` — 解 access token 的 JWT 第二段拿 `sub / email / aud`，用于反向同步时识别"IDE 这次自刷的是哪个账号"
+- **新增**: `watchKiroAuthTokenFile` — 用 `fs.watchFile` 监听磁盘 token 变化 + 内容防抖；账号管理器主进程启动时自动挂上
+- **新增**: **反向同步链路** — Kiro IDE 自己 refresh 后写新 token 到磁盘 → 反代 watcher 检测到 → JWT sub 三层匹配（sub / lastSwitchedAccountId / refreshToken）找到反代 store 里的账号 → 更新 credentials → `webContents.send('kiro-ide-token-changed')` 通知 renderer 重新 loadAccounts，UI 立刻看到最新 expiresAt
+- **新增**: 防回环 — 反代自己刚写入的 token 签名 `lastWrittenTokenSignature` 会被 watcher 识别并跳过，避免 IDE / 反代来回打架
+- **新增**: `switchAccount` IPC 返回 `refreshedCredentials`（含 refresh 后真实的 access/refresh/expiresIn），renderer 立即同步到 store；解决"反代 store 仍存 v1 → 下次刷新撞已作废 refresh"的连锁问题
+
+#### 🛡️ BuilderId 占位符 profileArn 闭环修复
+
+- **修复**: 🔥 **Kiro IDE 桌面端 `FixedProfileArns` 给 BuilderId 硬编码占位符 ARN `profile/AAAACCCCXXXX`** — 反代直接调 `codewhisperer.us-east-1.amazonaws.com/ListAvailableModels` 携带此 ARN 必触发 403 "User is not authorized to make this call."。本工具反代侧 `kiroApi.ts` 的 `resolveProfileArn` 改为：BuilderId 与未知 provider 不附加任何 profileArn；所有调用点（`fetchKiroModels` / `callKiroApiStream` / 订阅三接口）全部加判空守护
+- **修复**: 🔥 **`switch-account` / `switch-account-cli` / `refresh-account-token`（同步分支）/ `runProactiveRenewal` 等 4 处写入路径仍内联占位符 ARN** — BuilderId 账号会被强行塞这个占位符到 `~/.aws/sso/cache/kiro-auth-token.json` 或 `~/.local/share/kiro-cli/data.sqlite3`，导致 Kiro IDE / kiro-cli 后续走 REST 端点的调用同样被埋雷。现统一改用 `resolveProfileArnForWrite` helper：BuilderId 永远返回 `undefined`
+- **新增**: `kiroAuthSync.ts` 集中维护 `KIRO_BUILDER_ID_PLACEHOLDER_ARN` / `KIRO_SOCIAL_PROFILE_ARN` 常量；反代 `kiroApi.ts` 改为 re-export，消除 5 处常量重复定义的漂移风险
+- **新增**: `writeKiroAuthTokenFile` 内部加防线 — 检测到调用方传入占位符 ARN 自动 strip 为 `undefined`，任何漏掉 helper 的路径仍被兜底
+- **新增**: 启动时 `migrateAccountDataIfNeeded` 一次性扫描 electron-store 里的账号数据，把已被旧版本 / Kiro IDE 写入的占位符 ARN 清空并幂等回写
+
+#### 🆕 新增：IDE Token 主动续期（Proactive Renewal，默认关闭）
+
+- **新增**: Settings → Auto Refresh 块下方新增 **「IDE 主动续期」** 开关 — 启用后账号管理器主进程会在 IDE 当前激活账号的 token 剩 ~15 分钟时抢先 refresh + 写磁盘，Kiro IDE 始终看到剩余 ≥ 45 分钟的 token，IDE 内部 `attemptRefreshIfCloseToExpiry` 永远不触发，彻底消除 IDE 与本工具同时 refresh 撞车 OIDC rotation 的 race 风险
+- **新增**: 仅对"当前 IDE 激活账号"维护一个 timer（开销最低）；`switch-account` / `refresh-account-token` / `logout-account` 都会正确调度或清理 timer，绝不泄漏
+- **新增**: 续期失败时 timer 停止 + 由 IDE 自己的 refresh loop 接管 — 与双向同步机制天然互补
+- **新增**: 持久化在 electron-store（`proactiveRenewalEnabled` 键），重启账号管理器后自动恢复
+
+#### 🧰 Kiro IDE 二进制补丁器 `scripts/patch-kiro-ide.cjs`
+
+- **新增**: 跨平台脚本 — 针对 Kiro IDE 桌面端 `extension.js` 与 `packages/kiro-shared` bundled JS 做 3 处精准正则替换：
+  - `getFixedProfileArn`：BuilderId 短路返回 `void 0`
+  - `supportsProfiles`：把 BuilderId 移出 IdC 列表
+  - `resolveProfileArn`：BuilderId token 直接返回 `void 0`
+- **新增**: 同时清理 `%APPDATA%/Kiro/User/globalStorage/kiro.kiro-agent/profile.json` 里写入的占位符 ARN
+- **新增**: 幂等（首行 MARKER）+ 备份（`.kpatch-backup`）+ `--dry-run` / `--restore` / `--verbose` / `--kiro-dir` 参数；Kiro IDE 升级覆盖后重新运行同一命令即可重打
+- **使用**: `node scripts/patch-kiro-ide.cjs --dry-run` 先预检，`node scripts/patch-kiro-ide.cjs` 正式打。建议完全退出 Kiro 后再执行
+
+#### 🔧 构建 / 发布
+
+- **修复**: 🔥 **macOS 自动更新 404** — `electron-builder` 默认行为下 mac zip 文件名把 `productName` 中的空格替换成 `.`（生成 `Kiro.Account.Manager-1.7.2-mac.zip`），但 `latest-mac.yml` 里的 `url` 字段把空格替换成 `-`（指向 `Kiro-Account-Manager-1.7.2-mac.zip`），两者 mismatch → updater 下载 404。`electron-builder.yml` 新增 `mac.artifactName: ${name}-${version}-${arch}-mac.${ext}` 与显式 `target: zip/dmg × [x64, arm64]`，让所有平台命名统一为 `kiro-account-manager-…` 风格，并让 `latest-mac.yml` 同时包含 x64 + arm64 双入口，Apple Silicon 用户能拿到 arm64 原生包
+- **注意**: 现有 v1.7.2 macOS 用户因上述 bug 仍无法自动升级到 v1.7.3，请到 [Releases](https://github.com/chaogei/Kiro-account-manager/releases/latest) 手动下载对应 dmg/zip 安装一次
+
+#### 🎨 UI / 细节调整
+
+- **优化**: 注册页面 — 「日志」卡片从页面最底部移到「开始注册」按钮所在卡片之后，操作时可一眼看到实时进度
+- **优化**: 账号工具栏 — 「批量检查账户信息」与「批量刷新 Token」两个按钮之前都用 `RefreshCw` 图标，肉眼分不清；现分别改为 `Activity`（检查/活动语义）与 `KeyRound`（刷新令牌语义，与卡片视图一致），并附 i18n tooltip
+- **新增**: Settings → Auto Refresh 块下加双向同步说明 — 明确「Kiro IDE 有自己的内部刷新循环」、「切号 / 刷新仅当账号是 IDE 当前激活账号才同步到磁盘」、「IDE 自刷后本工具会反向同步到 store」
+- **新增**: `onKiroIdeTokenChanged` IPC 事件 — renderer 收到后自动 `loadFromStorage`，IDE 自刷后 UI 立刻刷新 expiresAt
+
+#### 🔍 验证
+
+- 全项目 `npm run typecheck:node && npm run typecheck:web` 两段 zero error 通过
+- ReadLints 对全部改动文件零警告
+- Kiro IDE 补丁脚本 `--dry-run` 在 Windows 实测 D:\Program\Kiro 上 5 个目标文件全部精准命中（3 + 1 + 1 + 1 + 1 处替换）
+
+
 ### v1.7.2 (2026-6-2) — 批量订阅链接增强 + 卡密解析修复 + 添加/导入分组归属
 
 > 本版本聚焦批量订阅「获取链接」界面的批量导入与快选分批打开、卡密/凭证解析的边界字符修复（解决导入验证 401），以及添加 / 批量 / 导入账号时可归入指定分组。


### PR DESCRIPTION
…更新修复

核心修复：解决"切号/刷新 Token 后 Kiro IDE 约 1 小时后被强制登出"
- switch-account 写入磁盘的 refreshToken 是已被服务端 rotate 作废的旧值
- refresh-account-token 从来不写磁盘文件（"刷新 Token"按钮对 IDE 无效）
- background-batch-refresh（自动刷新）同样不写磁盘（最大隐藏漏洞）
- expiresAt 硬编码 +1h、refresh 失败仍写旧 token 等连锁问题

新增 Kiro IDE Token 双向同步：
- 新模块 src/main/kiroAuthSync.ts：writeKiroAuthTokenFile / readKiroAuthTokenFile / parseAccessTokenClaims（JWT 解 sub）/ watchKiroAuthTokenFile
- 主进程启动时挂 fs.watchFile 监听 ~/.aws/sso/cache/kiro-auth-token.json
- IDE 自刷后通过 JWT sub 三层匹配反向同步到反代 store，UI 立即刷新
- 防回环（lastWrittenTokenSignature）、switchAccount 返回 refreshedCredentials

BuilderId 占位符 ARN 闭环：
- 集中化 resolveProfileArnForWrite helper，BuilderId 永远返回 undefined
- switch-account / switch-account-cli / refresh-account-token / runProactiveRenewal / background-batch-refresh 全部改用 helper
- writeKiroAuthTokenFile 内部加最后防线，自动 strip 占位符
- kiroApi.ts 改 re-export，消除 5 处常量重复定义
- 启动一次性 migrateAccountDataIfNeeded 清理 store 里的脏数据

新增 IDE Token 主动续期（默认关闭）：
- Settings → Auto Refresh 下方加开关
- 仅对 IDE 当前激活账号维护 1 个 timer，在 token 剩 15min 时抢先 refresh
- IDE 永远看到剩余 ≥ 45min，内部 refresh loop 永不触发
- 续期失败时由 IDE 自身 loop 接管，与双向同步互补

Kiro IDE 二进制补丁器 scripts/patch-kiro-ide.cjs：
- 跨平台、幂等、备份；3 处正则替换 + profile.json 清理
- 支持 --dry-run / --restore / --verbose / --kiro-dir

macOS 自动更新 404 修复：
- electron-builder.yml mac 段加 artifactName: ${name}-${version}-${arch}-mac.${ext}
- 显式 target: zip/dmg × [x64, arm64]
- latest-mac.yml 与磁盘文件名一致，arm64 用户拿原生包
- v1.7.2 macOS 用户需手动下载升级一次

UI / 细节：
- 注册页面日志卡片从底部移到"开始注册"按钮下方
- 工具栏 batchCheck 改 Activity 图标、batchRefresh 改 KeyRound 图标
- Settings 加双向同步说明（中英文）
- onKiroIdeTokenChanged IPC 事件，renderer 自动 reload accounts