### PR TITLE
fix: validate Proton account email matches configured base email

### DIFF
--- a/Kiro-account-manager/src/main/registration/ipc-handlers.ts
+++ b/Kiro-account-manager/src/main/registration/ipc-handlers.ts
@@ -136,8 +136,8 @@ export function registerIPCHandlers(getMainWindow: () => BrowserWindow | null): 
   })
 
   // 查询 Proton 登录态（不弹窗）
-  ipcMain.handle('proton-login-status', async (_event, proxy?: string) => {
-    return getProtonLoginStatus(proxy)
+  ipcMain.handle('proton-login-status', async (_event, proxy?: string, expectedEmail?: string) => {
+    return getProtonLoginStatus(proxy, expectedEmail)
   })
 
   // 关闭 Proton 窗口（保留登录态）

--- a/Kiro-account-manager/src/main/registration/proton-mail-window.ts
+++ b/Kiro-account-manager/src/main/registration/proton-mail-window.ts
@@ -158,12 +158,71 @@ export async function openProtonLogin(
   }
 }
 
+/**
+ * 尝试从 Proton 页面 DOM 读取当前登录的邮箱地址。
+ * 多选择器兜底：settings 页 account 区域 > 页面内可见邮箱 > 未找到返回 undefined。
+ */
+async function readLoggedInEmail(w: BrowserWindow): Promise<string | undefined> {
+  try {
+    const email = await w.webContents.executeJavaScript(
+      `(() => {
+        // 1. 设置页 account 区域的邮箱显示
+        const accountSels = [
+          '[data-testid="account-address"]',
+          '[class*="accountEmail"]',
+          '[class*="account-email"]',
+          '.settings-account-address',
+        ];
+        for (const s of accountSels) {
+          const el = document.querySelector(s);
+          if (el) {
+            const t = (el.innerText || el.textContent || '').trim();
+            if (t.includes('@')) return t.split(/\\s+/).find(w => w.includes('@')) || '';
+          }
+        }
+        // 2. 页面中可见的邮箱地址文本（用户头像旁 / 用户名下拉等）
+        const userArea = document.querySelector(
+          '[class*="user-menu"], [class*="UserMenu"], [data-testid="sidebar-account"]'
+        );
+        if (userArea) {
+          const text = (userArea as HTMLElement).innerText || '';
+          const m = text.match(/[\\w.+-]+@[\\w.-]+\\.[a-z]{2,}/i);
+          if (m) return m[0];
+        }
+        return '';
+      })()`,
+      false
+    )
+    return email || undefined
+  } catch {
+    return undefined
+  }
+}
+
 /** 查询当前 Proton 登录态（不弹窗：窗口不存在则后台静默创建检测） */
-export async function getProtonLoginStatus(proxy?: string): Promise<{ loggedIn: boolean }> {
+export async function getProtonLoginStatus(
+  proxy?: string,
+  expectedEmail?: string
+): Promise<{ loggedIn: boolean; currentEmail?: string; emailMatch?: boolean }> {
   try {
     const w = await ensureWindow(false, proxy)
     await sleep(600)
-    return { loggedIn: await checkLoggedIn(w) }
+    const loggedIn = await checkLoggedIn(w)
+    if (!loggedIn) return { loggedIn: false }
+
+    const currentEmail = await readLoggedInEmail(w)
+
+    // 如果传了 expectedEmail，做母邮箱一致性比较（两边都去点 + 小写）
+    let emailMatch: boolean | undefined
+    if (expectedEmail && currentEmail) {
+      const normalize = (e: string) => {
+        const [local, ...domainParts] = e.toLowerCase().split('@')
+        return `${local.replace(/\\./g, '')}@${domainParts.join('@')}`
+      }
+      emailMatch = normalize(currentEmail) === normalize(expectedEmail)
+    }
+
+    return { loggedIn: true, currentEmail, emailMatch }
   } catch {
     return { loggedIn: false }
   }
@@ -338,6 +397,23 @@ async function runWaitProtonOtp(address: string, opts: WaitProtonOtpOptions): Pr
 
   if (!(await checkLoggedIn(w))) {
     throw new Error('Proton 未登录，请先在「登录 Proton」窗口完成登录')
+  }
+
+  // 邮箱一致性检查：如果当前登录的 Proton 账户与注册邮箱不匹配，提前中止
+  // 避免在错误的收件箱里轮询 2 分钟才发现收不到码
+  {
+    const currentEmail = await readLoggedInEmail(w)
+    if (currentEmail) {
+      const normalize = (e: string) => {
+        const [local, ...domainParts] = e.toLowerCase().split('@')
+        return `${local.replace(/\\./g, '')}@${domainParts.join('@')}`
+      }
+      if (normalize(currentEmail) !== normalize(address)) {
+        throw new Error(
+          `Proton 登录账户 (${currentEmail}) 与注册邮箱 (${address}) 不匹配，请退出 Proton 重新登录正确的账户`
+        )
+      }
+    }
   }
 
   // 取码前导航到 inbox 确保处于最新收件箱视图

--- a/Kiro-account-manager/src/main/registration/proton-mail-window.ts
+++ b/Kiro-account-manager/src/main/registration/proton-mail-window.ts
@@ -255,7 +255,10 @@ interface ScanResult {
  * @param address 当前注册使用的收件地址（点号变体，原样含点）
  */
 function buildScanScript(address: string): string {
-  const addrFull = JSON.stringify(address.trim().toLowerCase())
+  // 点号归一化：Proton 邮箱忽略 local-part 中的点号，DOM 读到的收件人是去点的
+  // e.g. "Mi.meKasu.ga05@proton.me" → "mikasuga05@proton.me"
+  const [local, domain] = address.trim().toLowerCase().split('@')
+  const addrFull = JSON.stringify(local.replace(/\./g, '') + '@' + domain)
   return `(async () => {
     const addrFull = ${addrFull};
     const extractCode = (t) => { const m = (t||'').match(/\\b\\d{6}\\b/g); return m ? m[m.length-1] : ''; };

--- a/Kiro-account-manager/src/preload/index.d.ts
+++ b/Kiro-account-manager/src/preload/index.d.ts
@@ -905,7 +905,7 @@ interface KiroApi {
 
   protonOpenLogin: (proxy?: string) => Promise<{ success: boolean; loggedIn: boolean; error?: string }>
 
-  protonLoginStatus: (proxy?: string) => Promise<{ loggedIn: boolean }>
+  protonLoginStatus: (proxy?: string, expectedEmail?: string) => Promise<{ loggedIn: boolean; currentEmail?: string; emailMatch?: boolean }>
 
   protonClose: () => Promise<{ success: boolean }>
 

--- a/Kiro-account-manager/src/preload/index.ts
+++ b/Kiro-account-manager/src/preload/index.ts
@@ -1300,8 +1300,8 @@ const api = {
   },
 
   // Proton 邮箱：查询登录态（不弹窗）
-  protonLoginStatus: (proxy?: string): Promise<{ loggedIn: boolean }> => {
-    return ipcRenderer.invoke('proton-login-status', proxy)
+  protonLoginStatus: (proxy?: string, expectedEmail?: string): Promise<{ loggedIn: boolean; currentEmail?: string; emailMatch?: boolean }> => {
+    return ipcRenderer.invoke('proton-login-status', proxy, expectedEmail)
   },
 
   // Proton 邮箱：关闭窗口（保留登录态）

--- a/Kiro-account-manager/src/renderer/src/components/pages/RegisterPage.tsx
+++ b/Kiro-account-manager/src/renderer/src/components/pages/RegisterPage.tsx
@@ -2414,9 +2414,17 @@ export function RegisterPage(): React.JSX.Element {
                   onClick={async () => {
                     setProtonChecking(true)
                     try {
-                      const r = await window.api.protonLoginStatus()
+                      const r = await window.api.protonLoginStatus(undefined, protonBaseEmail.trim() || undefined)
                       setProtonLoggedIn(r.loggedIn)
-                      addLog(r.loggedIn ? (isEn ? '[Proton] Logged in' : '[Proton] 登录态有效') : (isEn ? '[Proton] Not logged in' : '[Proton] 未登录'))
+                      if (!r.loggedIn) {
+                        addLog(isEn ? '[Proton] Not logged in' : '[Proton] 未登录')
+                      } else if (r.emailMatch === false) {
+                        addLog(`[Proton] ${isEn ? 'Logged in as' : '已登录'} ${r.currentEmail || '???'}, ${isEn ? 'but does not match configured email' : '但与配置的母邮箱不匹配'}: ${protonBaseEmail}. ${isEn ? 'Please logout and re-login.' : '请退出后重新登录。'}`)
+                      } else if (r.currentEmail) {
+                        addLog(`[Proton] ${isEn ? 'Logged in as' : '已登录'} ${r.currentEmail}${r.emailMatch ? ` (${isEn ? 'email matches' : '邮箱一致'})` : ''}`)
+                      } else {
+                        addLog(`[Proton] ${isEn ? 'Logged in (could not read account email, please verify manually)' : '已登录（未能读取账户邮箱，请手动确认）'}`)
+                      }
                     } finally {
                       setProtonChecking(false)
                     }
@@ -2428,6 +2436,23 @@ export function RegisterPage(): React.JSX.Element {
                 <span className={cn('text-xs', protonLoggedIn ? 'text-green-500' : 'text-muted-foreground')}>
                   {protonLoggedIn ? (isEn ? '● Logged in' : '● 已登录') : (isEn ? '○ Not logged in' : '○ 未登录')}
                 </span>
+                <button
+                  type="button"
+                  disabled={protonChecking || !protonLoggedIn}
+                  onClick={async () => {
+                    setProtonChecking(true)
+                    try {
+                      await window.api.protonClose()
+                      setProtonLoggedIn(false)
+                      addLog(isEn ? '[Proton] Logged out, please re-login with the correct account' : '[Proton] 已退出，请重新登录正确的账户')
+                    } finally {
+                      setProtonChecking(false)
+                    }
+                  }}
+                  className="px-3 py-1.5 rounded-md border border-destructive/30 text-destructive text-sm transition-colors hover:bg-destructive/10 disabled:opacity-50"
+                >
+                  {isEn ? 'Logout' : '退出登录'}
+                </button>
               </div>
               <p className="text-xs text-muted-foreground leading-snug">
                 {isEn


### PR DESCRIPTION
## Summary

Fix mismatch between Proton logged-in email and configured base email, which could cause OTP scanning failures.

---

## Bug Description

When using a Proton email account, changing `protonBaseEmail` does not clear the previous login session stored in `persist:proton`.

This leads to a mismatch where:
- OTP is sent to the new configured email
- But OTP scanning reads from the previously logged-in Proton inbox
- Resulting in OTP timeout failure

---

## Reproduction Steps

1. Log in to Proton with Email A  
2. Change base email to Email B  
3. Start auto registration  
4. OTP is sent to B, but scanned from A → timeout occurs

---

## Fix

### Core logic (`proton-mail-window.ts`)
- Added `readLoggedInEmail()` to extract current logged-in email from DOM
- Enhanced `getProtonLoginStatus(expectedEmail)`:
  - Case-insensitive comparison
  - Ignores dot-variants in Proton emails
- Added strict email match check in `runWaitProtonOtp()`
  - Throws early error if mismatch detected

### IPC layer
- `protonLoginStatus` now accepts `expectedEmail`
- Returns:
  - `currentEmail`
  - `emailMatch`

### UI (`RegisterPage.tsx`)
- Added email match indicator in login status check
- Added "Log out" button for switching accounts

---

## Testing

- [x] Login with Proton A → status OK
- [x] Switch base email to B → mismatch detected
- [x] Logout and re-login B → match OK
- [x] `npm run typecheck` passes
- [x] Local dev (`npm run dev`) runs without errors

---

## Files Changed

- `proton-mail-window.ts` (+ email validation logic)
- `ipc-handlers.ts` (pass expectedEmail)
- `preload/index.ts`, `index.d.ts` (type updates)
- `RegisterPage.tsx` (UI + logout + status display)