### PR TITLE
fix(proxy): update Kiro runtime and complete Responses tool compatibility

### DIFF
--- a/Kiro-account-manager/package.json
+++ b/Kiro-account-manager/package.json
@@ -20,6 +20,7 @@
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
+    "test:unit": "node --test test/responses-translator.test.mjs",
     "test:e2e": "node test/e2e-fullsuite/run.mjs",
     "test:e2e:only": "node test/e2e-fullsuite/run.mjs --only"
   },

--- a/Kiro-account-manager/src/main/proxy/kiroApi.ts
+++ b/Kiro-account-manager/src/main/proxy/kiroApi.ts
@@ -143,32 +143,23 @@ async function fetchWithProxy(url: string, options: RequestInit, account?: Proxy
   return await fetch(url, options)
 }
 
-// Kiro API 端点配置
-const KIRO_ENDPOINTS = [
-  {
-    url: 'https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse',
-    origin: 'AI_EDITOR',
-    amzTarget: 'AmazonCodeWhispererStreamingService.GenerateAssistantResponse',
-    name: 'CodeWhisperer',
-    protocol: 'generateAssistantResponse' as const
-  },
-  {
-    url: 'https://q.us-east-1.amazonaws.com/generateAssistantResponse',
-    origin: 'AI_EDITOR',
-    amzTarget: 'AmazonCodeWhispererStreamingService.GenerateAssistantResponse',
-    name: 'AmazonQ',
-    protocol: 'generateAssistantResponse' as const
-  },
-  {
-    url: 'https://q.us-east-1.amazonaws.com/SendMessageStreaming',
-    origin: 'CLI',
-    amzTarget: 'AmazonQDeveloperStreamingService.SendMessage',
-    name: 'AmazonQCLI'
+interface KiroEndpoint {
+  url: string
+  origin: string
+  name: 'KiroRuntime'
+}
+
+function getKiroRuntimeEndpoint(region?: string): KiroEndpoint {
+  const resolvedRegion = region?.trim() || 'us-east-1'
+  return {
+    url: `https://runtime.${resolvedRegion}.kiro.dev/`,
+    origin: 'KIRO_CLI',
+    name: 'KiroRuntime'
   }
-]
+}
 
 // Kiro 版本号（跟随官方 IDE 更新）
-const KIRO_VERSION = '0.12.155'
+const KIRO_VERSION = '0.12.333'
 const AWS_SDK_VERSION = '1.0.34'
 const AWS_STREAMING_API_VERSION = '1.0.34'
 
@@ -264,11 +255,6 @@ REMEMBER: When in doubt, write LESS per operation. Multiple small operations > o
 const THINKING_MODE_PROMPT = `<thinking_mode>enabled</thinking_mode>
 <max_thinking_length>200000</max_thinking_length>`
 
-const CODEWHISPERER_DEFAULT_MODEL_ID = 'CLAUDE_SONNET_4_20250514_V1_0'
-const CODEWHISPERER_MODEL_CACHE_TTL = 5 * 60 * 1000
-
-const codeWhispererModelCache = new Map<string, { models: KiroModel[]; timestamp: number }>()
-
 // 模型 ID 映射
 const MODEL_ID_MAP: Record<string, string> = {
   // Claude 4.5 系列
@@ -319,86 +305,30 @@ export function mapModelId(model: string): string {
   // 0) 归一化版本号短横 → 点号（claude-opus-4-6 → claude-opus-4.6），兼容不支持 "." 的客户端
   modelId = normalizeClaudeVersion(modelId)
   const lower = modelId.toLowerCase()
+  if (lower.startsWith('qdev::')) return modelId
   // 1) 显式 alias 映射优先
   if (MODEL_ID_MAP[lower]) return MODEL_ID_MAP[lower]
   // 2) 看似 Kiro 支持的 Claude 模型格式 (claude-{sonnet|haiku|opus}-{ver})，原样透传
   //    用于向前兼容尚未加入 MODEL_ID_MAP 的新发布模型
   if (/^claude-(sonnet|haiku|opus)-/.test(lower)) return modelId
-  // 3) 完全未知的 model（用户拼错/不存在），兜底到 default 避免直接 400
-  console.warn(`[Kiro API] Unknown model "${modelId}" → fallback to "${MODEL_ID_MAP.default}"`)
-  return MODEL_ID_MAP.default
+  // 3) Kiro 的模型目录由服务端驱动。新模型 ID 必须原样透传，不能静默
+  //    改写为已经过期的本地 Claude 兜底模型。
+  console.warn(`[Kiro API] Unknown local model "${modelId}" → forwarding verbatim`)
+  return modelId
 }
 
 function clonePayload(payload: KiroPayload): KiroPayload {
   return JSON.parse(JSON.stringify(payload)) as KiroPayload
 }
 
-function normalizeModelKey(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, '')
-}
-
-function modelTokens(value: string): string[] {
-  return value.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
-}
-
-function matchesRequestedModel(model: KiroModel, requestedModelId: string): boolean {
-  // 1. modelId 级精确匹配（去除符号后比较）
-  const requestedKey = normalizeModelKey(requestedModelId)
-  const modelIdKey = normalizeModelKey(model.modelId)
-  if (modelIdKey === requestedKey || modelIdKey.includes(requestedKey)) return true
-  // 2. modelName 精确匹配
-  if (model.modelName && normalizeModelKey(model.modelName).includes(requestedKey)) return true
-  // 3. token 匹配（所有请求 token 必须在 modelId+modelName 中命中，不搜索 description 避免误匹配）
-  const tokens = modelTokens(requestedModelId).filter(token => token !== 'latest' && token !== 'model')
-  if (tokens.length === 0) return false
-  const candidateTokens = new Set(modelTokens(`${model.modelId} ${model.modelName || ''}`))
-  // 必须全部 token 命中
-  if (!tokens.every(token => candidateTokens.has(token))) return false
-  // 防止模型家族冲突：如果请求包含 opus/sonnet/haiku，候选必须也包含对应的
-  const families = ['opus', 'sonnet', 'haiku']
-  for (const family of families) {
-    if (tokens.includes(family) && !candidateTokens.has(family)) return false
-    if (!tokens.includes(family) && candidateTokens.has(family)) return false
-  }
-  return true
-}
-
 function isCodeWhispererModelId(modelId: string): boolean {
   return /^[A-Z0-9_]+$/.test(modelId) && modelId.includes('_')
-}
-
-function getModelCacheKey(account: ProxyAccount): string {
-  return `${account.id}:${account.region || 'us-east-1'}:${resolveProfileArn(account) ?? 'no-arn'}`
-}
-
-async function getCachedCodeWhispererModels(account: ProxyAccount, signal?: AbortSignal): Promise<KiroModel[]> {
-  const key = getModelCacheKey(account)
-  const cached = codeWhispererModelCache.get(key)
-  if (cached && Date.now() - cached.timestamp < CODEWHISPERER_MODEL_CACHE_TTL) return cached.models
-  const models = await fetchKiroModels(account, signal)
-  codeWhispererModelCache.set(key, { models, timestamp: Date.now() })
-  return models
-}
-
-async function resolveCodeWhispererModelId(account: ProxyAccount, requestedModelId?: string, signal?: AbortSignal): Promise<string> {
-  const modelId = requestedModelId?.trim()
-  if (!modelId) return CODEWHISPERER_DEFAULT_MODEL_ID
-  if (isCodeWhispererModelId(modelId)) return modelId
-  const models = await getCachedCodeWhispererModels(account, signal)
-  return models.find(model => matchesRequestedModel(model, modelId))?.modelId || CODEWHISPERER_DEFAULT_MODEL_ID
 }
 
 function getPayloadModelId(payload: KiroPayload): string | undefined {
   const currentModelId = payload.conversationState.currentMessage.userInputMessage.modelId
   if (currentModelId) return currentModelId
   return payload.conversationState.history?.find(message => message.userInputMessage?.modelId)?.userInputMessage?.modelId
-}
-
-function applyPayloadModelId(payload: KiroPayload, modelId: string): void {
-  payload.conversationState.currentMessage.userInputMessage.modelId = modelId
-  for (const message of payload.conversationState.history ?? []) {
-    if (message.userInputMessage) message.userInputMessage.modelId = modelId
-  }
 }
 
 function applyPayloadOrigin(payload: KiroPayload, origin: string): void {
@@ -1148,10 +1078,8 @@ function fingerprintFromHistory(history: KiroHistoryMessage[]): string | undefin
 // 清除所有内存缓存
 export function clearAllCaches(): { conversation: number; model: number } {
   const conversationCount = conversationCache.size
-  const modelCount = codeWhispererModelCache.size
   conversationCache.clear()
-  codeWhispererModelCache.clear()
-  return { conversation: conversationCount, model: modelCount }
+  return { conversation: conversationCount, model: 0 }
 }
 
 // machineId 稳定生成缓存（用于无绑定 machineId 且 K-Proxy 不可用时的兆底）
@@ -1178,7 +1106,7 @@ function getAccountMachineId(accountId: string, accountMachineId?: string): stri
 }
 
 // 获取认证方式对应的请求头
-function getAuthHeaders(account: ProxyAccount, _endpoint: typeof KIRO_ENDPOINTS[0]): Record<string, string> {
+function getAuthHeaders(account: ProxyAccount): Record<string, string> {
   const machineId = getAccountMachineId(account.id, account.machineId)
   // 按配置的 agent 模式（vibe 或 spec）设置 header
   const agentMode = configuredAgentMode
@@ -1201,25 +1129,14 @@ function getAuthHeaders(account: ProxyAccount, _endpoint: typeof KIRO_ENDPOINTS[
   return headers
 }
 
-// 获取排序后的端点列表（根据首选端点配置）
-function getSortedEndpoints(preferredEndpoint?: 'codewhisperer' | 'amazonq' | 'amazonq-cli'): typeof KIRO_ENDPOINTS {
-  if (!preferredEndpoint) return KIRO_ENDPOINTS.filter(ep => ep.name !== 'AmazonQCLI')
-  
-  // AmazonQ CLI 模式：只用这一个端点，失败不回退
-  if (preferredEndpoint === 'amazonq-cli') {
-    return KIRO_ENDPOINTS.filter(ep => ep.name === 'AmazonQCLI')
-  }
-  
-  const preferredName = preferredEndpoint === 'codewhisperer' ? 'CodeWhisperer' : 'AmazonQ'
-  
-  const sorted = KIRO_ENDPOINTS.filter(ep => ep.name !== 'AmazonQCLI')
-  sorted.sort((a, b) => {
-    if (a.name === preferredName) return -1
-    if (b.name === preferredName) return 1
-    return 0
-  })
-  
-  return sorted
+// Current Kiro tokens are accepted by the Kiro runtime service. The legacy
+// CodeWhisperer/Amazon Q endpoints reject those tokens, so old preferences are
+// intentionally retained only as stored-config compatibility.
+function getSortedEndpoints(
+  _preferredEndpoint?: 'codewhisperer' | 'amazonq' | 'amazonq-cli',
+  region?: string
+): KiroEndpoint[] {
+  return [getKiroRuntimeEndpoint(region)]
 }
 
 function getAbortError(signal?: AbortSignal): Error {
@@ -1245,7 +1162,7 @@ export async function callKiroApiStream(
 ): Promise<void> {
   const isEnterprise = account.provider === 'Enterprise' || account.authMethod === 'external_idp'
   // 所有账号类型均走正常端点优先级（含 fallback），不再强制 Enterprise 走 CodeWhisperer
-  const endpoints = getSortedEndpoints(preferredEndpoint)
+  const endpoints = getSortedEndpoints(preferredEndpoint, account.region)
 
   // Enterprise 缺 profileArn 时调 API 获取；BuilderId/Social 不需要（resolveProfileArn 会兜底，流式端点自动不传占位符）
   if (!account.profileArn && isEnterprise) {
@@ -1269,20 +1186,10 @@ export async function callKiroApiStream(
         requestPayload.profileArn = resolvedArn
       }
       const requestedModelId = getPayloadModelId(requestPayload)
-      if (endpoint.name === 'CodeWhisperer') {
-        applyPayloadModelId(requestPayload, await resolveCodeWhispererModelId(account, requestedModelId, signal))
-      }
-
       applyPayloadOrigin(requestPayload, endpoint.origin)
 
-      // AmazonQCLI 端点不支持 agentContinuationId/agentTaskType
-      if (endpoint.name === 'AmazonQCLI') {
-        delete (requestPayload.conversationState as unknown as Record<string, unknown>).agentContinuationId
-        delete (requestPayload.conversationState as unknown as Record<string, unknown>).agentTaskType
-      }
-
       const payloadStr = JSON.stringify(requestPayload)
-      const headers = getAuthHeaders(account, endpoint)
+      const headers = getAuthHeaders(account)
       const currentUserInput = requestPayload.conversationState.currentMessage.userInputMessage
       const historyMessages = requestPayload.conversationState.history ?? []
       const historyToolUseCount = historyMessages.reduce((count, message) => count + (message.assistantResponseMessage?.toolUses?.length ?? 0), 0)
@@ -1365,12 +1272,9 @@ export async function callKiroApiStream(
           } else {
             delete retryPayload.profileArn
           }
-          if (endpoint.name === 'CodeWhisperer') {
-            applyPayloadModelId(retryPayload, await resolveCodeWhispererModelId(account, getPayloadModelId(retryPayload), signal))
-          }
           applyPayloadOrigin(retryPayload, endpoint.origin)
           const retryStr = JSON.stringify(retryPayload)
-          const retryHeaders = getAuthHeaders(account, endpoint)
+          const retryHeaders = getAuthHeaders(account)
           const retryAgent = getNetworkAgent(account)
           const retryResponse = retryAgent
             ? await undiciFetch(endpoint.url, { method: 'POST', headers: retryHeaders, body: retryStr, signal, dispatcher: retryAgent } as UndiciRequestInit) as unknown as Response
@@ -2308,7 +2212,8 @@ export async function fetchEnterpriseProfileArn(account: ProxyAccount): Promise<
 
 // 获取 Kiro 官方模型列表（支持分页，与官方插件一致传递 profileArn）
 export async function fetchKiroModels(account: ProxyAccount, signal?: AbortSignal): Promise<KiroModel[]> {
-  const baseUrl = getQServiceEndpoint(account.region)
+  const region = account.region?.trim() || 'us-east-1'
+  const baseUrl = `https://management.${region}.kiro.dev`
   const machineId = getAccountMachineId(account.id, account.machineId)
   
   const headers: Record<string, string> = {

--- a/Kiro-account-manager/src/main/proxy/proxyServer.ts
+++ b/Kiro-account-manager/src/main/proxy/proxyServer.ts
@@ -30,7 +30,9 @@ import {
   createOpenaiStreamChunk,
   createClaudeStreamEvent,
   responsesToOpenAIChat,
-  openAIChatToResponsesResponse
+  openAIChatToResponsesResponse,
+  restorePreviousResponse,
+  rememberResponseConversation
 } from './translator'
 import { ToolNameRegistry } from './toolNameRegistry'
 import { promptCacheTracker } from './promptCacheTracker'
@@ -194,7 +196,8 @@ function buildClientModel(input: {
   const outputModalities: ModelModality[] = ['text']
   const output = modelOutputLimit(input.id, input.maxOutputTokens)
   const context = typeof input.maxInputTokens === 'number' && input.maxInputTokens > 0 ? input.maxInputTokens : 200000
-  const hasThinking = !!(input.additionalModelRequestFieldsSchema?.properties as Record<string, unknown> | undefined)?.thinking || !!(input.additionalModelRequestFieldsSchema?.properties as Record<string, unknown> | undefined)?.output_config
+  const modelRequestProperties = input.additionalModelRequestFieldsSchema?.properties as Record<string, unknown> | undefined
+  const hasThinking = !!modelRequestProperties?.thinking || !!modelRequestProperties?.output_config || !!modelRequestProperties?.reasoning
   const reasoning = hasThinking
   const interleaved = hasThinking ? { field: 'reasoning_content' as const } : false
 
@@ -236,7 +239,7 @@ function buildClientModel(input: {
     inputTypes: input.supportedInputTypes,
     rateMultiplier: input.rateMultiplier,
     rateUnit: input.rateUnit,
-    supportsThinking: !!(input.additionalModelRequestFieldsSchema?.properties as Record<string, unknown> | undefined)?.thinking || !!(input.additionalModelRequestFieldsSchema?.properties as Record<string, unknown> | undefined)?.output_config,
+    supportsThinking: hasThinking,
     thinkingEfforts: extractThinkingSchema(input.additionalModelRequestFieldsSchema)?.efforts,
     thinkingSchemaPath: extractThinkingSchema(input.additionalModelRequestFieldsSchema)?.schemaPath,
     supportsPromptCaching: input.promptCaching?.supportsPromptCaching || false,
@@ -1060,7 +1063,7 @@ export class ProxyServer {
       maxOutputTokens: m.tokenLimits?.maxOutputTokens,
       rateMultiplier: m.rateMultiplier,
       rateUnit: m.rateUnit,
-      supportsThinking: !!(m.additionalModelRequestFieldsSchema?.properties as Record<string, unknown> | undefined)?.thinking || !!(m.additionalModelRequestFieldsSchema?.properties as Record<string, unknown> | undefined)?.output_config,
+      supportsThinking: !!extractThinkingSchema(m.additionalModelRequestFieldsSchema),
       thinkingEfforts: extractThinkingSchema(m.additionalModelRequestFieldsSchema)?.efforts,
       thinkingSchemaPath: extractThinkingSchema(m.additionalModelRequestFieldsSchema)?.schemaPath,
       supportsPromptCaching: m.promptCaching?.supportsPromptCaching || false,
@@ -1103,18 +1106,7 @@ export class ProxyServer {
       }
     }
 
-    // 合并隐藏模型（与 /v1/models 端点一致）
-    const modelIds = new Set(kiroModels.map(m => m.modelId))
-    const hiddenModels: KiroModel[] = [
-      { modelId: 'claude-3.7-sonnet', modelName: 'Claude 3.7 Sonnet', description: 'Claude 3.7 Sonnet (hidden)', supportedInputTypes: ['TEXT', 'IMAGE'], tokenLimits: { maxInputTokens: 200000, maxOutputTokens: 64000 } } as KiroModel,
-      { modelId: 'simple-task', modelName: 'Simple Task', description: 'Kiro fast model (routes to Haiku)', supportedInputTypes: ['TEXT'], tokenLimits: { maxInputTokens: 200000, maxOutputTokens: 4096 } } as KiroModel,
-      { modelId: 'CLAUDE_SONNET_4_20250514_V1_0', modelName: 'Claude Sonnet 4 (CW)', description: 'CodeWhisperer internal ID', supportedInputTypes: ['TEXT', 'IMAGE'], tokenLimits: { maxInputTokens: 200000, maxOutputTokens: 64000 } } as KiroModel,
-      { modelId: 'CLAUDE_HAIKU_4_5_20251001_V1_0', modelName: 'Claude Haiku 4.5 (CW)', description: 'CodeWhisperer internal ID', supportedInputTypes: ['TEXT', 'IMAGE'], tokenLimits: { maxInputTokens: 200000, maxOutputTokens: 64000 } } as KiroModel,
-      { modelId: 'CLAUDE_3_7_SONNET_20250219_V1_0', modelName: 'Claude 3.7 Sonnet (CW)', description: 'CodeWhisperer internal ID', supportedInputTypes: ['TEXT', 'IMAGE'], tokenLimits: { maxInputTokens: 200000, maxOutputTokens: 64000 } } as KiroModel
-    ]
-    const merged = [...kiroModels, ...hiddenModels.filter(m => !modelIds.has(m.modelId))]
-
-    return { models: merged.map(ProxyServer.mapKiroModelToApi), fromCache }
+    return { models: kiroModels.map(ProxyServer.mapKiroModelToApi), fromCache }
   }
 
   // 检查 Token 是否需要刷新
@@ -2373,32 +2365,6 @@ export class ProxyServer {
   private async handleModels(res: http.ServerResponse, signal?: AbortSignal): Promise<void> {
     const now = Date.now()
     
-    // Kiro 官方模型（与 UI 保持一致）
-    const kiroOfficialModels = [
-      buildClientModel({ id: 'auto', created: now, ownedBy: 'kiro-api', description: 'Auto select best model' }),
-      buildClientModel({ id: 'claude-sonnet-4.5', created: now, ownedBy: 'kiro-api', description: 'The latest Claude Sonnet model' }),
-      buildClientModel({ id: 'claude-sonnet-4', created: now, ownedBy: 'kiro-api', description: 'Hybrid reasoning and coding' }),
-      buildClientModel({ id: 'claude-haiku-4.5', created: now, ownedBy: 'kiro-api', description: 'The latest Claude Haiku model' }),
-      buildClientModel({ id: 'claude-opus-4.5', created: now, ownedBy: 'kiro-api', description: 'The most powerful model' })
-    ]
-
-    // 隐藏模型（未在官方 ListAvailableModels 中返回，但后端可能支持）
-    const hiddenModels = [
-      buildClientModel({ id: 'claude-3.7-sonnet', created: now, ownedBy: 'kiro-api', description: 'Claude 3.7 Sonnet (hidden)', modelName: 'Claude 3.7 Sonnet', supportedInputTypes: ['TEXT', 'IMAGE'], maxInputTokens: 200000, maxOutputTokens: 64000 }),
-      buildClientModel({ id: 'simple-task', created: now, ownedBy: 'kiro-api', description: 'Kiro fast model for intent classification and lightweight tasks (routes to Haiku)', modelName: 'Simple Task', supportedInputTypes: ['TEXT'], maxInputTokens: 200000, maxOutputTokens: 4096 }),
-      buildClientModel({ id: 'CLAUDE_SONNET_4_20250514_V1_0', created: now, ownedBy: 'kiro-api', description: 'Claude Sonnet 4 (CodeWhisperer internal ID)', modelName: 'Claude Sonnet 4 (CW)', supportedInputTypes: ['TEXT', 'IMAGE'], maxInputTokens: 200000, maxOutputTokens: 64000 }),
-      buildClientModel({ id: 'CLAUDE_HAIKU_4_5_20251001_V1_0', created: now, ownedBy: 'kiro-api', description: 'Claude Haiku 4.5 (CodeWhisperer internal ID)', modelName: 'Claude Haiku 4.5 (CW)', supportedInputTypes: ['TEXT', 'IMAGE'], maxInputTokens: 200000, maxOutputTokens: 64000 }),
-      buildClientModel({ id: 'CLAUDE_3_7_SONNET_20250219_V1_0', created: now, ownedBy: 'kiro-api', description: 'Claude 3.7 Sonnet (CodeWhisperer internal ID)', modelName: 'Claude 3.7 Sonnet (CW)', supportedInputTypes: ['TEXT', 'IMAGE'], maxInputTokens: 200000, maxOutputTokens: 64000 })
-    ]
-
-    // 预设模型（GPT 兼容别名）
-    const presetModels = [
-      buildClientModel({ id: 'gpt-4o', created: now, ownedBy: 'kiro-proxy', description: 'GPT-compatible alias for Kiro' }),
-      buildClientModel({ id: 'gpt-4', created: now, ownedBy: 'kiro-proxy', description: 'GPT-compatible alias for Kiro' }),
-      buildClientModel({ id: 'gpt-4-turbo', created: now, ownedBy: 'kiro-proxy', description: 'GPT-compatible alias for Kiro' }),
-      buildClientModel({ id: 'gpt-3.5-turbo', created: now, ownedBy: 'kiro-proxy', description: 'GPT-compatible alias for Kiro' })
-    ]
-
     // 尝试从 Kiro API 获取动态模型
     let kiroModels: KiroModel[] = []
     
@@ -2445,39 +2411,9 @@ export class ProxyServer {
       modelProvider: m.modelProvider
     }))
 
-    // 合并模型列表，去重
-    const modelIds = new Set<string>()
-    const allModels: ClientModel[] = []
-    
-    // 1. 优先添加动态模型（从 API 获取的，包含真实 token limit / input types）
-    for (const m of dynamicModels) {
-      if (!modelIds.has(m.id)) {
-        modelIds.add(m.id)
-        allModels.push(m)
-      }
-    }
-    
-    // 2. 添加隐藏模型（未在官方 ListAvailableModels 中返回，但后端可能支持）
-    for (const m of hiddenModels) {
-      if (!modelIds.has(m.id)) {
-        modelIds.add(m.id)
-        allModels.push(m)
-      }
-    }
-    
-    // 3. 动态模型缺失时才添加静态兜底
-    if (dynamicModels.length === 0) {
-      for (const m of [...kiroOfficialModels, ...presetModels]) {
-        if (!modelIds.has(m.id)) {
-          modelIds.add(m.id)
-          allModels.push(m)
-        }
-      }
-    }
-
     this.throwIfResponseClosed(res, signal)
     res.writeHead(200, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify({ object: 'list', data: allModels }))
+    res.end(JSON.stringify({ object: 'list', data: dynamicModels }))
   }
 
   // 处理 OpenAI Chat Completions 请求
@@ -2619,6 +2555,7 @@ export class ProxyServer {
     try {
       responseRequest = JSON.parse(body)
       chatRequest = responsesToOpenAIChat(responseRequest)
+      chatRequest = restorePreviousResponse(chatRequest, responseRequest.previous_response_id)
       // session hint：用于会话粘性
       const rawHintResp = ProxyServer.extractSessionHint(req, responseRequest)
       if (rawHintResp) {
@@ -2677,6 +2614,7 @@ export class ProxyServer {
         this.throwIfResponseClosed(res, signal)
         const response = openAIChatToResponsesResponse(chatResponse, responseRequest.previous_response_id)
         const streamedResponse = { ...response, id: responseId }
+        rememberResponseConversation(responseId, processedRequest, chatResponse)
         streamedResponse.output.forEach((item, outputIndex) => {
           this.throwIfResponseClosed(res, signal)
           res.write(`event: response.output_item.added\ndata: ${JSON.stringify({ type: 'response.output_item.added', output_index: outputIndex, item })}\n\n`)
@@ -2728,6 +2666,7 @@ export class ProxyServer {
       const chatResponse = kiroToOpenaiResponse(result.content, result.toolUses, result.usage, chatRequest.model, toolNameRegistry, result.reasoningContent)
       this.throwIfResponseClosed(res, signal)
       const response = openAIChatToResponsesResponse(chatResponse, responseRequest.previous_response_id)
+      rememberResponseConversation(response.id, processedRequest, chatResponse)
 
       this.recordRequestSuccess()
       this.stats.totalTokens += result.usage.inputTokens + result.usage.outputTokens

--- a/Kiro-account-manager/src/main/proxy/translator.ts
+++ b/Kiro-account-manager/src/main/proxy/translator.ts
@@ -170,7 +170,7 @@ export function responsesToOpenAIChat(request: OpenAIResponsesRequest): OpenAICh
             id: item.call_id,
             type: 'function',
             function: {
-              name: item.name,
+              name: encodeResponseToolName(item.namespace, item.name),
               arguments: item.arguments
             }
           }]
@@ -196,15 +196,124 @@ export function responsesToOpenAIChat(request: OpenAIResponsesRequest): OpenAICh
   }
   if (request.temperature !== undefined) chatRequest.temperature = request.temperature
   if (request.top_p !== undefined) chatRequest.top_p = request.top_p
+  if (request.reasoning?.effort !== undefined) chatRequest.reasoning_effort = request.reasoning.effort
   if (request.max_output_tokens !== undefined) chatRequest.max_tokens = request.max_output_tokens
   if (request.stream !== undefined) chatRequest.stream = request.stream
-  if (request.tools !== undefined) chatRequest.tools = request.tools
+  if (request.tools !== undefined) chatRequest.tools = convertResponseTools(request.tools)
   const toolChoice = convertResponseToolChoice(request.tool_choice)
   if (toolChoice !== undefined) chatRequest.tool_choice = toolChoice
   if (request.previous_response_id !== undefined) chatRequest.conversation_id = request.previous_response_id
   if (request.metadata !== undefined) chatRequest.metadata = request.metadata
   if (request.kiro_context !== undefined) chatRequest.kiro_context = request.kiro_context
   return chatRequest
+}
+
+const RESPONSE_HOSTED_TOOL_TYPES = new Set([
+  'web_search',
+  'web_search_preview',
+  'file_search',
+  'computer_use_preview',
+  'code_interpreter',
+  'image_generation'
+])
+
+function convertResponseTools(tools: NonNullable<OpenAIResponsesRequest['tools']>): OpenAITool[] {
+  if (!Array.isArray(tools)) {
+    throw new Error('Responses tools must be an array')
+  }
+
+  return tools.flatMap(tool => {
+    const rawTool = tool as unknown as Record<string, unknown>
+    const toolType = rawTool.type
+
+    if (toolType === 'namespace') {
+      const namespace = rawTool.name
+      const nestedTools = rawTool.tools
+      if (typeof namespace !== 'string' || !Array.isArray(nestedTools)) {
+        throw new Error('Responses namespace tool requires name and tools')
+      }
+
+      return nestedTools.map(nestedToolValue => {
+        const nestedTool = nestedToolValue as Record<string, unknown>
+        if (nestedTool.type !== 'function' || typeof nestedTool.name !== 'string') {
+          throw new Error(`Unsupported tool in Responses namespace: ${String(nestedTool.type)}`)
+        }
+        return {
+          type: 'function' as const,
+          function: {
+            name: encodeResponseToolName(namespace, nestedTool.name),
+            description: typeof nestedTool.description === 'string'
+              ? nestedTool.description
+              : typeof rawTool.description === 'string'
+                ? rawTool.description
+                : `Tool: ${namespace}/${nestedTool.name}`,
+            parameters: nestedTool.parameters ?? { type: 'object', properties: {} }
+          }
+        }
+      })
+    }
+
+    // Hosted OpenAI tools execute inside OpenAI's platform and cannot be
+    // translated to Kiro's client-executed function tool protocol.
+    if (typeof toolType === 'string' && RESPONSE_HOSTED_TOOL_TYPES.has(toolType)) {
+      return []
+    }
+    if (toolType !== 'function') {
+      throw new Error(`Unsupported responses tool type: ${String(toolType)}`)
+    }
+
+    const nestedFunction = rawTool.function as Record<string, unknown> | undefined
+    if (nestedFunction) {
+      if (typeof nestedFunction.name !== 'string') {
+        throw new Error('Responses function tool requires name')
+      }
+      return [{
+        type: 'function' as const,
+        function: {
+          name: nestedFunction.name,
+          description: typeof nestedFunction.description === 'string'
+            ? nestedFunction.description
+            : `Tool: ${nestedFunction.name}`,
+          parameters: nestedFunction.parameters ?? { type: 'object', properties: {} }
+        }
+      }]
+    }
+
+    if (typeof rawTool.name !== 'string') {
+      throw new Error('Responses function tool requires name')
+    }
+    return [{
+      type: 'function' as const,
+      function: {
+        name: rawTool.name,
+        description: typeof rawTool.description === 'string' ? rawTool.description : `Tool: ${rawTool.name}`,
+        parameters: rawTool.parameters ?? { type: 'object', properties: {} }
+      }
+    }]
+  })
+}
+
+const RESPONSE_NAMESPACE_PREFIX = '__kiro_ns_'
+
+function encodeResponseToolName(namespace: string | undefined, name: string): string {
+  return namespace ? `${RESPONSE_NAMESPACE_PREFIX}${namespace.length}__${namespace}${name}` : name
+}
+
+function decodeResponseToolName(encodedName: string): { name: string; namespace?: string } {
+  if (!encodedName.startsWith(RESPONSE_NAMESPACE_PREFIX)) return { name: encodedName }
+  const lengthEnd = encodedName.indexOf('__', RESPONSE_NAMESPACE_PREFIX.length)
+  if (lengthEnd < 0) return { name: encodedName }
+
+  const namespaceLength = Number(encodedName.slice(RESPONSE_NAMESPACE_PREFIX.length, lengthEnd))
+  if (!Number.isInteger(namespaceLength) || namespaceLength < 1) return { name: encodedName }
+
+  const namespaceStart = lengthEnd + 2
+  const nameStart = namespaceStart + namespaceLength
+  if (nameStart >= encodedName.length) return { name: encodedName }
+  return {
+    namespace: encodedName.slice(namespaceStart, nameStart),
+    name: encodedName.slice(nameStart)
+  }
 }
 
 function convertResponseInputContent(content: string | OpenAIResponseContentPart[] | undefined): OpenAIMessage['content'] {
@@ -247,10 +356,62 @@ function convertResponseToolChoice(toolChoice: OpenAIResponsesRequest['tool_choi
   if (!toolChoice || typeof toolChoice === 'string') return toolChoice
   if (toolChoice.type === 'none' || toolChoice.type === 'auto') return toolChoice.type
   if (toolChoice.type === 'function' && toolChoice.name) {
-    return { type: 'function', function: { name: toolChoice.name } }
+    return { type: 'function', function: { name: encodeResponseToolName(toolChoice.namespace, toolChoice.name) } }
   }
   if (toolChoice.function?.name) return { type: 'function', function: { name: toolChoice.function.name } }
   throw new Error('Unsupported responses tool_choice')
+}
+
+interface ResponsesConversationState {
+  messages: OpenAIMessage[]
+  tools?: OpenAITool[]
+}
+
+const RESPONSES_CONVERSATION_CACHE_MAX = 100
+const responsesConversationCache = new Map<string, ResponsesConversationState>()
+
+export function restorePreviousResponse(
+  chatRequest: OpenAIChatRequest,
+  previousResponseId?: string
+): OpenAIChatRequest {
+  if (!previousResponseId) return chatRequest
+  const previous = responsesConversationCache.get(previousResponseId)
+  if (!previous) return chatRequest
+
+  // Refresh LRU order while rebuilding the full tool transcript required by
+  // Kiro's stateless runtime endpoint.
+  responsesConversationCache.delete(previousResponseId)
+  responsesConversationCache.set(previousResponseId, previous)
+  return {
+    ...chatRequest,
+    messages: [...previous.messages, ...chatRequest.messages],
+    tools: chatRequest.tools ?? previous.tools
+  }
+}
+
+export function rememberResponseConversation(
+  responseId: string,
+  processedRequest: OpenAIChatRequest,
+  chatResponse: OpenAIChatResponse
+): void {
+  const assistantMessages: OpenAIMessage[] = chatResponse.choices.map(choice => ({
+    role: 'assistant',
+    content: choice.message.content ?? '',
+    ...(choice.message.reasoning_content !== undefined
+      ? { reasoning_content: choice.message.reasoning_content }
+      : {}),
+    ...(choice.message.tool_calls !== undefined ? { tool_calls: choice.message.tool_calls } : {})
+  }))
+
+  responsesConversationCache.set(responseId, {
+    messages: [...processedRequest.messages, ...assistantMessages],
+    tools: processedRequest.tools
+  })
+  while (responsesConversationCache.size > RESPONSES_CONVERSATION_CACHE_MAX) {
+    const oldestResponseId = responsesConversationCache.keys().next().value
+    if (oldestResponseId === undefined) break
+    responsesConversationCache.delete(oldestResponseId)
+  }
 }
 
 export function openAIChatToResponsesResponse(
@@ -259,13 +420,17 @@ export function openAIChatToResponsesResponse(
 ): OpenAIResponsesResponse {
   const output: OpenAIResponseOutputItem[] = response.choices.flatMap<OpenAIResponseOutputItem>(choice => {
     if (choice.message.tool_calls?.length) {
-      return choice.message.tool_calls.map(toolCall => ({
-        type: 'function_call' as const,
-        id: `fc_${uuidv4()}`,
-        call_id: toolCall.id,
-        name: toolCall.function.name,
-        arguments: toolCall.function.arguments
-      }))
+      return choice.message.tool_calls.map(toolCall => {
+        const decodedName = decodeResponseToolName(toolCall.function.name)
+        return {
+          type: 'function_call' as const,
+          id: `fc_${uuidv4()}`,
+          call_id: toolCall.id,
+          name: decodedName.name,
+          ...(decodedName.namespace ? { namespace: decodedName.namespace } : {}),
+          arguments: toolCall.function.arguments
+        }
+      })
     }
     return [{
       type: 'message' as const,
@@ -293,6 +458,7 @@ export function openAIChatToResponsesResponse(
     id: `resp_${uuidv4()}`,
     object: 'response',
     created_at: response.created,
+    status: 'completed',
     model: response.model,
     output,
     usage
@@ -517,8 +683,14 @@ export function openaiToKiro(
   const kiroTools = convertOpenAITools(request.tools, toolNameRegistry)
 
   // OpenAI 兼容请求的 thinking/reasoning_effort 映射到 Kiro additionalModelRequestFields
+  // Codex may call /v1/responses before /v1/models has populated the schema
+  // cache. Current GPT 5.6 models use Kiro's reasoning.effort schema rather
+  // than Anthropic's thinking object, so retain a safe family fallback.
+  const effectiveThinkingConfig = thinkingConfig ?? (/^gpt-5\.6-/i.test(modelId)
+    ? { schemaPath: 'reasoning' as const, efforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'] }
+    : undefined)
   const additionalModelRequestFields = buildThinkingFields(
-    thinkingConfig,
+    effectiveThinkingConfig,
     request.thinking as { type: string; budget_tokens?: number },
     request.reasoning_effort
   )

--- a/Kiro-account-manager/src/main/proxy/types.ts
+++ b/Kiro-account-manager/src/main/proxy/types.ts
@@ -112,13 +112,39 @@ export interface OpenAIResponsesRequest {
   top_p?: number
   max_output_tokens?: number
   stream?: boolean
-  tools?: OpenAITool[]
-  tool_choice?: string | { type: string; name?: string; function?: { name: string } }
+  tools?: OpenAIResponsesTool[]
+  tool_choice?: string | { type: string; name?: string; namespace?: string; function?: { name: string } }
   previous_response_id?: string
-  reasoning?: unknown
+  reasoning?: { effort?: string; [key: string]: unknown }
   metadata?: Record<string, unknown>
   kiro_context?: KiroRequestContext
 }
+
+export type OpenAIResponsesTool =
+  | OpenAITool
+  | {
+      type: 'function'
+      name: string
+      description?: string
+      parameters?: unknown
+      strict?: boolean
+    }
+  | {
+      type: 'namespace'
+      name: string
+      description?: string
+      tools: Array<{
+        type: 'function'
+        name: string
+        description?: string
+        parameters?: unknown
+        strict?: boolean
+      }>
+    }
+  | {
+      type: 'web_search' | 'web_search_preview' | 'file_search' | 'computer_use_preview' | 'code_interpreter' | 'image_generation'
+      [key: string]: unknown
+    }
 
 export interface OpenAIResponseInputItem {
   type?: 'message' | 'function_call' | 'function_call_output'
@@ -126,6 +152,7 @@ export interface OpenAIResponseInputItem {
   content?: string | OpenAIResponseContentPart[]
   call_id?: string
   name?: string
+  namespace?: string
   arguments?: string
   output?: string
 }
@@ -142,6 +169,7 @@ export interface OpenAIResponsesResponse {
   id: string
   object: 'response'
   created_at: number
+  status: 'completed'
   model: string
   output: OpenAIResponseOutputItem[]
   previous_response_id?: string
@@ -156,7 +184,7 @@ export interface OpenAIResponsesResponse {
 
 export type OpenAIResponseOutputItem =
   | { type: 'message'; id: string; role: 'assistant'; content: { type: 'output_text'; text: string }[] }
-  | { type: 'function_call'; id: string; call_id: string; name: string; arguments: string }
+  | { type: 'function_call'; id: string; call_id: string; name: string; namespace?: string; arguments: string }
 
 // ============ Claude 兼容格式 ============
 export interface ClaudeRequest {

--- a/Kiro-account-manager/test/responses-translator.test.mjs
+++ b/Kiro-account-manager/test/responses-translator.test.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { pathToFileURL } from 'node:url'
+import ts from 'typescript'
+
+const projectRoot = path.resolve(import.meta.dirname, '..')
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kam-responses-translator-'))
+
+function transpile(sourcePath, outputName) {
+  const source = fs.readFileSync(sourcePath, 'utf8')
+  const result = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022
+    }
+  })
+  const output = result.outputText
+    .replace("from 'uuid'", "from './uuid.mjs'")
+    .replace("'./kiroApi'", "'./kiroApi.mjs'")
+    .replace("'./toolNameRegistry'", "'./toolNameRegistry.mjs'")
+  fs.writeFileSync(path.join(tempDir, outputName), output)
+}
+
+transpile(path.join(projectRoot, 'src/main/proxy/translator.ts'), 'translator.mjs')
+transpile(path.join(projectRoot, 'src/main/proxy/toolNameRegistry.ts'), 'toolNameRegistry.mjs')
+fs.writeFileSync(
+  path.join(tempDir, 'kiroApi.mjs'),
+  'export const mapModelId = model => model\nexport const buildKiroPayload = () => ({})\n'
+)
+fs.writeFileSync(path.join(tempDir, 'uuid.mjs'), "export const v4 = () => 'test-uuid'\n")
+
+const {
+  openAIChatToResponsesResponse,
+  rememberResponseConversation,
+  responsesToOpenAIChat,
+  restorePreviousResponse
+} = await import(pathToFileURL(path.join(tempDir, 'translator.mjs')).href)
+
+function chatResponse(message) {
+  return {
+    id: 'chat_1',
+    object: 'chat.completion',
+    created: 1,
+    model: 'gpt-5.6-sol',
+    choices: [{ index: 0, message, finish_reason: message.tool_calls ? 'tool_calls' : 'stop' }],
+    usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 }
+  }
+}
+
+test('converts flat Responses function tools to Chat Completions tools', () => {
+  const request = responsesToOpenAIChat({
+    model: 'gpt-5.6-sol',
+    input: 'weather?',
+    reasoning: { effort: 'high' },
+    tools: [
+      {
+        type: 'function',
+        name: 'get_weather',
+        description: 'Get weather',
+        parameters: { type: 'object', properties: { city: { type: 'string' } } }
+      }
+    ]
+  })
+
+  assert.equal(request.reasoning_effort, 'high')
+  assert.deepEqual(request.tools?.[0], {
+    type: 'function',
+    function: {
+      name: 'get_weather',
+      description: 'Get weather',
+      parameters: { type: 'object', properties: { city: { type: 'string' } } }
+    }
+  })
+})
+
+test('flattens namespace tools and restores namespace on function calls', () => {
+  const request = responsesToOpenAIChat({
+    model: 'gpt-5.6-sol',
+    input: 'list files',
+    tools: [
+      {
+        type: 'namespace',
+        name: 'shell',
+        tools: [{ type: 'function', name: 'exec', parameters: { type: 'object' } }]
+      }
+    ]
+  })
+  const encodedName = request.tools?.[0].function.name
+  assert.match(encodedName, /^__kiro_ns_5__shellexec$/)
+
+  const response = openAIChatToResponsesResponse(
+    chatResponse({
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: { name: encodedName, arguments: '{"cmd":"pwd"}' }
+        }
+      ]
+    })
+  )
+
+  assert.equal(response.status, 'completed')
+  assert.deepEqual(
+    { namespace: response.output[0].namespace, name: response.output[0].name },
+    { namespace: 'shell', name: 'exec' }
+  )
+})
+
+test('restores previous_response_id history for tool result turns', () => {
+  const firstRequest = responsesToOpenAIChat({
+    model: 'gpt-5.6-sol',
+    input: 'weather?',
+    tools: [{ type: 'function', name: 'get_weather', parameters: { type: 'object' } }]
+  })
+  rememberResponseConversation(
+    'resp_previous',
+    firstRequest,
+    chatResponse({
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call_weather',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"city":"Shanghai"}' }
+        }
+      ]
+    })
+  )
+
+  const continuation = responsesToOpenAIChat({
+    model: 'gpt-5.6-sol',
+    previous_response_id: 'resp_previous',
+    input: [{ type: 'function_call_output', call_id: 'call_weather', output: 'Sunny, 30 C' }]
+  })
+  const restored = restorePreviousResponse(continuation, 'resp_previous')
+
+  assert.deepEqual(
+    restored.messages.map((message) => message.role),
+    ['user', 'assistant', 'tool']
+  )
+  assert.equal(restored.messages[2].content, 'Sunny, 30 C')
+  assert.equal(restored.tools?.[0].function.name, 'get_weather')
+})
+
+test('omits OpenAI-hosted tools that Kiro cannot execute', () => {
+  const request = responsesToOpenAIChat({
+    model: 'gpt-5.6-sol',
+    input: 'hello',
+    tools: [{ type: 'web_search' }]
+  })
+  assert.deepEqual(request.tools, [])
+})


### PR DESCRIPTION
## Summary

- route generation requests to the current regional Kiro Runtime service and model discovery to Kiro Management
- return only the server-provided model catalog and pass newly introduced model IDs through unchanged
- translate Responses API flat function tools and Codex namespace tools into Kiro-compatible function tools
- preserve namespace metadata on returned function calls and rebuild tool history for `previous_response_id` continuations
- map Responses `reasoning.effort`, return `status: completed`, and add focused unit coverage

## Root cause

The proxy still targeted the legacy Amazon Q/CodeWhisperer endpoints, which reject current Kiro credentials. Its Responses adapter also assigned the flat Responses `tools` array directly to the Chat Completions request shape, so downstream code dereferenced a missing `tool.function`. Codex additionally sends namespace tools and tool-result continuations that need explicit translation because the Kiro runtime is stateless.

## Compatibility notes

- OpenAI-hosted tools (`web_search`, `file_search`, `code_interpreter`, and similar) are omitted because Kiro cannot execute them; client-executed function and namespace tools remain available.
- `previous_response_id` history is kept in an in-memory LRU capped at 100 responses and is not persisted across application restarts.
- Existing stored endpoint preferences remain readable, but generation uses the current regional Kiro Runtime because the legacy endpoints no longer accept current Kiro tokens.

## Validation

- `npm run test:unit` — 4/4 passed
- Node and renderer TypeScript checks passed
- Electron/Vite production build passed
- Live macOS validation against a patched v1.7.5 installation:
  - regional model discovery succeeded
  - OpenAI Chat Completions, Responses, Anthropic Messages, and Gemini-compatible requests returned successfully
  - Codex CLI completed a normal turn and a shell-tool round trip
  - a Responses function call continued successfully using only `previous_response_id` plus `function_call_output`

Closes #111.
Related to #71, #72, and #90.
